### PR TITLE
Adding support for MicroMeter metrics in the service framework.

### DIFF
--- a/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/IntegrationTestServiceLauncher.java
+++ b/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/IntegrationTestServiceLauncher.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 public class IntegrationTestServiceLauncher {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PlatformServiceLauncher.class);
-  private static List<PlatformService> apps = new ArrayList<>();
+  private static final List<PlatformService> PLATFORM_SERVICES = new ArrayList<>();
 
   /** @param serviceNames list of services to start */
   public static void main(String[] serviceNames) {
@@ -30,7 +30,7 @@ public class IntegrationTestServiceLauncher {
         PlatformService app = PlatformServiceFactory.get(configClient);
         app.initialize();
         Runtime.getRuntime().addShutdownHook(new Thread(app::shutdown));
-        apps.add(app);
+        PLATFORM_SERVICES.add(app);
         app.start();
       } catch (Exception e) {
         LOGGER.error("Got exception while starting PlatformService: " + serviceName, e);
@@ -39,6 +39,6 @@ public class IntegrationTestServiceLauncher {
   }
 
   static void shutdown() {
-    apps.forEach(PlatformService::shutdown);
+    PLATFORM_SERVICES.forEach(PlatformService::shutdown);
   }
 }

--- a/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClient.java
+++ b/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClient.java
@@ -11,7 +11,7 @@ public class IntegrationTestConfigClient implements ConfigClient {
   private static final String APPLICATION_CONFIG_FILE = "application.conf";
   private static final String INTEGRATION_TEST_ENV = "local";
 
-  private String resourcePrefix;
+  private final String resourcePrefix;
 
   public IntegrationTestConfigClient(String resourcePrefix) {
     this.resourcePrefix = resourcePrefix;

--- a/platform-metrics/build.gradle.kts
+++ b/platform-metrics/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
   api("org.apache.flink:flink-metrics-core:1.10.1")
   api("org.apache.flink:flink-metrics-prometheus_2.12:1.10.1")
   api("javax.servlet:javax.servlet-api:3.1.0")
-  api("com.google.guava:guava:29.0-jre")
 
   implementation("io.micrometer:micrometer-registry-prometheus:1.5.3")
   implementation("io.github.mweirauch:micrometer-jvm-extras:0.2.0")

--- a/platform-metrics/build.gradle.kts
+++ b/platform-metrics/build.gradle.kts
@@ -11,10 +11,14 @@ tasks.test {
 
 dependencies {
   api("io.dropwizard.metrics:metrics-core:4.1.0")
+  api("io.micrometer:micrometer-core:1.5.3")
   api("org.apache.flink:flink-metrics-core:1.10.1")
   api("org.apache.flink:flink-metrics-prometheus_2.12:1.10.1")
   api("javax.servlet:javax.servlet-api:3.1.0")
+  api("com.google.guava:guava:29.0-jre")
 
+  implementation("io.micrometer:micrometer-registry-prometheus:1.5.3")
+  implementation("io.github.mweirauch:micrometer-jvm-extras:0.2.0")
   implementation("org.slf4j:slf4j-api:1.7.25")
   implementation("io.dropwizard.metrics:metrics-jvm:4.1.0")
   implementation("io.prometheus:simpleclient_dropwizard:0.6.0")

--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/MetricsServlet.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/MetricsServlet.java
@@ -36,8 +36,8 @@ public class MetricsServlet extends HttpServlet {
 
   private static final String NAME_PARAM_KEY = "name[]";
 
-  private CollectorRegistry registry;
-  private org.apache.flink.shaded.io.prometheus.client.CollectorRegistry flinkRegistry;
+  private final CollectorRegistry registry;
+  private final org.apache.flink.shaded.io.prometheus.client.CollectorRegistry flinkRegistry;
 
   public MetricsServlet() {
     this.registry = CollectorRegistry.defaultRegistry;
@@ -45,12 +45,11 @@ public class MetricsServlet extends HttpServlet {
   }
 
   protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
-      throws ServletException, IOException {
+      throws IOException {
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType(TextFormat.CONTENT_TYPE_004);
 
-    Writer writer = resp.getWriter();
-    try {
+    try (Writer writer = resp.getWriter()) {
       Set<String> includedNames = parse(req);
       // first write all the dropwizard metric samples
       TextFormat.write004(writer, registry.filteredMetricFamilySamples(includedNames));
@@ -58,8 +57,6 @@ public class MetricsServlet extends HttpServlet {
       TextFormat.write004(writer,
           adaptShadedFlinkMetricSamples(flinkRegistry.filteredMetricFamilySamples(includedNames)));
       writer.flush();
-    } finally {
-      writer.close();
     }
   }
 
@@ -119,7 +116,7 @@ public class MetricsServlet extends HttpServlet {
 
   @Override
   protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
-      throws ServletException, IOException {
+      throws IOException {
     doGet(req, resp);
   }
 

--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
@@ -149,7 +149,7 @@ public class PlatformMetricsRegistry {
   }
 
   public static Counter registerCounter(String name, Map<String, String> tags) {
-    return METER_REGISTRY.counter(String.format("%s.%s", metricsPrefix, name), addDefaultTags(tags));
+    return METER_REGISTRY.counter(name, addDefaultTags(tags));
   }
 
   public static Timer registerTimer(String name, Map<String, String> tags) {
@@ -157,7 +157,7 @@ public class PlatformMetricsRegistry {
   }
 
   public static Timer registerTimer(String name, Map<String, String> tags, boolean histogram) {
-    Timer.Builder builder = Timer.builder(String.format("%s.%s", metricsPrefix, name))
+    Timer.Builder builder = Timer.builder(name)
         .publishPercentiles(0.5, 0.95, 0.99)
         .tags(addDefaultTags(tags));
     if (histogram) {
@@ -167,7 +167,7 @@ public class PlatformMetricsRegistry {
   }
 
   public static <T extends Number> T registerGauge(String name, Map<String, String> tags, T number) {
-    return METER_REGISTRY.gauge(String.format("%s.%s", metricsPrefix, name), addDefaultTags(tags), number);
+    return METER_REGISTRY.gauge(name, addDefaultTags(tags), number);
   }
 
   /**

--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
@@ -8,7 +8,6 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.JvmAttributeGaugeSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
-import com.google.common.cache.Cache;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.Clock;
@@ -17,7 +16,6 @@ import io.micrometer.core.instrument.ImmutableTag;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
@@ -27,6 +25,8 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
 import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
+import io.micrometer.core.lang.NonNull;
+import io.micrometer.core.lang.Nullable;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +78,7 @@ public class PlatformMetricsRegistry {
     // Add Prometheus registry to the composite registry.
     METER_REGISTRY.add(new PrometheusMeterRegistry(new PrometheusConfig() {
       @Override
-      @Nonnull
+      @NonNull
       public Duration step() {
         return Duration.ofSeconds(reportInterval);
       }
@@ -106,7 +105,7 @@ public class PlatformMetricsRegistry {
 
     METER_REGISTRY.add(new LoggingMeterRegistry(new LoggingRegistryConfig() {
       @Override
-      @Nonnull
+      @NonNull
       public Duration step() {
         return Duration.ofSeconds(reportIntervalSec);
       }
@@ -220,7 +219,7 @@ public class PlatformMetricsRegistry {
   }
 
   /**
-   * Registers the given number as a Guage with the service's metric registry and reports it
+   * Registers the given number as a Gauge with the service's metric registry and reports it
    * periodically to the configured reporters. Apart from the given tags, the reporting service's
    * default tags also will be reported with the metrics.
    *
@@ -231,18 +230,6 @@ public class PlatformMetricsRegistry {
   }
 
   /**
-   * Registers metrics for the given Guava Cache with the service's metric registry and
-   * reports them periodically to the configured reporters. Apart from the given tags, the
-   * reporting service's default tags also will be reported with the metrics.
-   *
-   * See https://micrometer.io/docs/ref/cache for more details on the metrics.
-   */
-  public static void monitorGuavaCache(String name, Cache cache,
-      @javax.annotation.Nullable Map<String, String> tags) {
-    GuavaCacheMetrics.monitor(METER_REGISTRY, cache, name, addDefaultTags(tags));
-  }
-
-  /**
    * Registers metrics for the given executor service with the service's metric registry and
    * reports them periodically to the configured reporters. Apart from the given tags, the
    * reporting service's default tags also will be reported with the metrics.
@@ -250,7 +237,7 @@ public class PlatformMetricsRegistry {
    * See https://micrometer.io/docs/ref/jvm for more details on the metrics.
    */
   public static void monitorExecutorService(String name, ExecutorService executorService,
-      @javax.annotation.Nullable Map<String, String> tags) {
+      @Nullable Map<String, String> tags) {
     new ExecutorServiceMetrics(executorService, name, addDefaultTags(tags)).bindTo(METER_REGISTRY);
   }
 

--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
@@ -8,12 +8,36 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.JvmAttributeGaugeSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
+import java.time.Duration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +51,6 @@ public class PlatformMetricsRegistry {
   public static final int METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_DEFAULT = 30;
   public static final String DEFAULT_METRICS_PREFIX = "org.hypertrace.core.serviceframework";
 
-
   private static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
   private static ConsoleReporter consoleReporter;
   private static String metricsPrefix;
@@ -39,6 +62,19 @@ public class PlatformMetricsRegistry {
     put("thread", new ThreadStatesGaugeSet());
   }};
   private static boolean isInit = false;
+  private static final Set<Tag> DEFAULT_TAGS = new HashSet<>();
+  private static final MeterRegistry METER_REGISTRY = new PrometheusMeterRegistry(new PrometheusConfig() {
+    @Override
+    public Duration step() {
+      return Duration.ofSeconds(30);
+    }
+
+    @Override
+    @Nullable
+    public String get(String k) {
+      return null;
+    }
+  }, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
 
   private static void initPrometheusExporter() {
     LOGGER.info("Trying to init PrometheusReporter");
@@ -56,14 +92,14 @@ public class PlatformMetricsRegistry {
     consoleReporter.start(reportInterval, TimeUnit.SECONDS);
   }
 
-  public synchronized static void initMetricsRegistry() {
-    initMetricsRegistry(DEFAULT_METRICS_REPORTERS, DEFAULT_METRICS_PREFIX,
-        METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_DEFAULT);
+  public synchronized static void initMetricsRegistry(String serviceName, Map<String, String> tags) {
+    initMetricsRegistry(serviceName, DEFAULT_METRICS_REPORTERS, DEFAULT_METRICS_PREFIX,
+        METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_DEFAULT, tags);
   }
 
-  public synchronized static void initMetricsRegistry(final List<String> reporters,
-      final String prefix,
-      final int reportInterval) {
+  public synchronized static void initMetricsRegistry(String serviceName,
+      final List<String> reporters, final String prefix,
+      final int reportInterval, Map<String, String> tags) {
     if (isInit) {
       return;
     }
@@ -83,6 +119,21 @@ public class PlatformMetricsRegistry {
           LOGGER.warn("Cannot find metric reporter: {}", reporter);
       }
     }
+
+    // Add the service name and other given tags to the default tags list.
+    DEFAULT_TAGS.add(new ImmutableTag("app", serviceName));
+    tags.forEach((key, value) -> DEFAULT_TAGS.add(new ImmutableTag(key, value)));
+
+    // Register different metrics with the registry.
+    new ClassLoaderMetrics(DEFAULT_TAGS).bindTo(METER_REGISTRY);
+    new JvmGcMetrics(DEFAULT_TAGS).bindTo(METER_REGISTRY);
+    new ProcessorMetrics(DEFAULT_TAGS).bindTo(METER_REGISTRY);
+    new JvmThreadMetrics(DEFAULT_TAGS).bindTo(METER_REGISTRY);
+    new JvmMemoryMetrics(DEFAULT_TAGS).bindTo(METER_REGISTRY);
+
+    new ProcessMemoryMetrics().bindTo(METER_REGISTRY);
+    new ProcessThreadMetrics().bindTo(METER_REGISTRY);
+
     for (String key : DEFAULT_METRIC_SET.keySet()) {
       METRIC_REGISTRY
           .registerAll(String.format("%s.%s", metricsPrefix, key), DEFAULT_METRIC_SET.get(key));
@@ -97,8 +148,57 @@ public class PlatformMetricsRegistry {
     }
   }
 
+  public static Counter registerCounter(String name, Map<String, String> tags) {
+    return METER_REGISTRY.counter(String.format("%s.%s", metricsPrefix, name), addDefaultTags(tags));
+  }
+
+  public static Timer registerTimer(String name, Map<String, String> tags) {
+    return registerTimer(name, tags, false);
+  }
+
+  public static Timer registerTimer(String name, Map<String, String> tags, boolean histogram) {
+    Timer.Builder builder = Timer.builder(String.format("%s.%s", metricsPrefix, name))
+        .publishPercentiles(0.5, 0.95, 0.99)
+        .tags(addDefaultTags(tags));
+    if (histogram) {
+      builder = builder.publishPercentileHistogram();
+    }
+    return builder.register(METER_REGISTRY);
+  }
+
+  public static <T extends Number> T registerGauge(String name, Map<String, String> tags, T number) {
+    return METER_REGISTRY.gauge(String.format("%s.%s", metricsPrefix, name), addDefaultTags(tags), number);
+  }
+
+  /**
+   * Method to monitor the given Guava cache. You must call {@link CacheBuilder#recordStats()}
+   * prior to building the cache for metrics to be recorded.
+   */
+  public static void monitorGuavaCache(String name, Cache cache, @javax.annotation.Nullable Map<String, String> tags) {
+    GuavaCacheMetrics.monitor(METER_REGISTRY, cache, name, addDefaultTags(tags));
+  }
+
+  public static void monitorExecutorService(String name, ExecutorService executorService,
+      @javax.annotation.Nullable Map<String, String> tags) {
+    new ExecutorServiceMetrics(executorService, name, addDefaultTags(tags)).bindTo(METER_REGISTRY);
+  }
+
+  private static Iterable<Tag> addDefaultTags(Map<String, String> tags) {
+    if (tags == null || tags.isEmpty()) {
+      return DEFAULT_TAGS;
+    }
+
+    Set<Tag> newTags = new HashSet<>(DEFAULT_TAGS);
+    tags.forEach((k, v) -> newTags.add(new ImmutableTag(k, v)));
+    return newTags;
+  }
+
   public static MetricRegistry getMetricRegistry() {
     return METRIC_REGISTRY;
+  }
+
+  public static MeterRegistry getMeterRegistry() {
+    return METER_REGISTRY;
   }
 
   public static void stop() {

--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
@@ -9,7 +9,6 @@ import com.codahale.metrics.jvm.JvmAttributeGaugeSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.Clock;
@@ -25,6 +24,9 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;
@@ -37,7 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +50,7 @@ import org.slf4j.LoggerFactory;
 public class PlatformMetricsRegistry {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PlatformMetricsRegistry.class);
-  public static final int METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_DEFAULT = 30;
+  private static final int METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_DEFAULT = 30;
   public static final String DEFAULT_METRICS_PREFIX = "org.hypertrace.core.serviceframework";
 
   private static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
@@ -63,33 +65,58 @@ public class PlatformMetricsRegistry {
   }};
   private static boolean isInit = false;
   private static final Set<Tag> DEFAULT_TAGS = new HashSet<>();
-  private static final MeterRegistry METER_REGISTRY = new PrometheusMeterRegistry(new PrometheusConfig() {
-    @Override
-    public Duration step() {
-      return Duration.ofSeconds(30);
-    }
 
-    @Override
-    @Nullable
-    public String get(String k) {
-      return null;
-    }
-  }, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
+  /**
+   * Main MetricMeter registry, with which all the metrics should be registered. We use
+   * a {@link CompositeMeterRegistry} here so that we can even registry multiple registries
+   * like Prometheus and Logging registries, if needed.
+   */
+  private static final CompositeMeterRegistry METER_REGISTRY = new CompositeMeterRegistry();
 
-  private static void initPrometheusExporter() {
+  private static void initPrometheusExporter(int reportInterval) {
     LOGGER.info("Trying to init PrometheusReporter");
+
+    // Add Prometheus registry to the composite registry.
+    METER_REGISTRY.add(new PrometheusMeterRegistry(new PrometheusConfig() {
+      @Override
+      @Nonnull
+      public Duration step() {
+        return Duration.ofSeconds(reportInterval);
+      }
+
+      @Override
+      @io.micrometer.core.lang.Nullable
+      public String get(String k) {
+        return null;
+      }
+    }, CollectorRegistry.defaultRegistry, Clock.SYSTEM));
+
     CollectorRegistry.defaultRegistry.register(new DropwizardExports(METRIC_REGISTRY));
   }
 
-  private static void initConsoleMetricsReporter() {
-    initConsoleMetricsReporter(METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_DEFAULT);
-  }
-
-  private static void initConsoleMetricsReporter(final int reportInterval) {
+  private static void initConsoleMetricsReporter(final int reportIntervalSec) {
     consoleReporter = ConsoleReporter.forRegistry(METRIC_REGISTRY).build();
     LOGGER
-        .info("Trying to init ConsoleReporter with reporter interval=[{}] seconds", reportInterval);
-    consoleReporter.start(reportInterval, TimeUnit.SECONDS);
+        .info("Trying to init ConsoleReporter with reporter interval=[{}] seconds", reportIntervalSec);
+    consoleReporter.start(reportIntervalSec, TimeUnit.SECONDS);
+  }
+
+  private static void initLoggingMetricsReporter(int reportIntervalSec) {
+    LOGGER.info("Initializing the logging metric reporter.");
+
+    METER_REGISTRY.add(new LoggingMeterRegistry(new LoggingRegistryConfig() {
+      @Override
+      @Nonnull
+      public Duration step() {
+        return Duration.ofSeconds(reportIntervalSec);
+      }
+
+      @Override
+      @io.micrometer.core.lang.Nullable
+      public String get(String key) {
+        return null;
+      }
+    }, Clock.SYSTEM));
   }
 
   public synchronized static void initMetricsRegistry(String serviceName, Map<String, String> tags) {
@@ -99,7 +126,7 @@ public class PlatformMetricsRegistry {
 
   public synchronized static void initMetricsRegistry(String serviceName,
       final List<String> reporters, final String prefix,
-      final int reportInterval, Map<String, String> tags) {
+      final int reportIntervalSec, Map<String, String> tags) {
     if (isInit) {
       return;
     }
@@ -107,13 +134,15 @@ public class PlatformMetricsRegistry {
     metricsPrefix = prefix;
 
     for (String reporter : reporters) {
-
       switch (reporter.toLowerCase()) {
         case "console":
-          initConsoleMetricsReporter(reportInterval);
+          initConsoleMetricsReporter(reportIntervalSec);
+          break;
+        case "logging":
+          initLoggingMetricsReporter(reportIntervalSec);
           break;
         case "prometheus":
-          initPrometheusExporter();
+          initPrometheusExporter(reportIntervalSec);
           break;
         default:
           LOGGER.warn("Cannot find metric reporter: {}", reporter);
@@ -141,6 +170,11 @@ public class PlatformMetricsRegistry {
     isInit = true;
   }
 
+  /**
+   * This method is deprecated since we'll be removing the Dropwizard metrics support in
+   * future releases.
+   */
+  @Deprecated
   public static void register(String metricName, Metric metric) {
     final String fullMetricName = String.format("%s.%s", metricsPrefix, metricName);
     if (!METRIC_REGISTRY.getNames().contains(fullMetricName)) {
@@ -148,14 +182,35 @@ public class PlatformMetricsRegistry {
     }
   }
 
+  /**
+   * Registers a Counter with the given name with the service's metric registry and reports it
+   * periodically to the configured reporters. Apart from the given tags, the reporting service's
+   * default tags also will be reported with the metrics.
+   *
+   * See https://micrometer.io/docs/concepts#_counters for more details on the Counter.
+   */
   public static Counter registerCounter(String name, Map<String, String> tags) {
     return METER_REGISTRY.counter(name, addDefaultTags(tags));
   }
 
+  /**
+   * Registers a Timer (without histograms) with the given name with the service's metric registry
+   * and reports it periodically to the configured reporters. Apart from the given tags, the
+   * reporting service's default tags also will be reported with the metrics.
+   *
+   * See https://micrometer.io/docs/concepts#_timers for more details on the Timer.
+   */
   public static Timer registerTimer(String name, Map<String, String> tags) {
     return registerTimer(name, tags, false);
   }
 
+  /**
+   * Registers a Timer with the given name with the service's metric registry and reports it
+   * periodically to the configured reporters. Apart from the given tags, the reporting service's
+   * default tags also will be reported with the metrics.
+   *
+   * See https://micrometer.io/docs/concepts#_timers for more details on the Timer.
+   */
   public static Timer registerTimer(String name, Map<String, String> tags, boolean histogram) {
     Timer.Builder builder = Timer.builder(name)
         .publishPercentiles(0.5, 0.95, 0.99)
@@ -166,18 +221,36 @@ public class PlatformMetricsRegistry {
     return builder.register(METER_REGISTRY);
   }
 
+  /**
+   * Registers the given number as a Guage with the service's metric registry and reports it
+   * periodically to the configured reporters. Apart from the given tags, the reporting service's
+   * default tags also will be reported with the metrics.
+   *
+   * See https://micrometer.io/docs/concepts#_gauges for more details on the Gauges.
+   */
   public static <T extends Number> T registerGauge(String name, Map<String, String> tags, T number) {
     return METER_REGISTRY.gauge(name, addDefaultTags(tags), number);
   }
 
   /**
-   * Method to monitor the given Guava cache. You must call {@link CacheBuilder#recordStats()}
-   * prior to building the cache for metrics to be recorded.
+   * Registers metrics for the given Guava Cache with the service's metric registry and
+   * reports them periodically to the configured reporters. Apart from the given tags, the
+   * reporting service's default tags also will be reported with the metrics.
+   *
+   * See https://micrometer.io/docs/ref/cache for more details on the metrics.
    */
-  public static void monitorGuavaCache(String name, Cache cache, @javax.annotation.Nullable Map<String, String> tags) {
+  public static void monitorGuavaCache(String name, Cache cache,
+      @javax.annotation.Nullable Map<String, String> tags) {
     GuavaCacheMetrics.monitor(METER_REGISTRY, cache, name, addDefaultTags(tags));
   }
 
+  /**
+   * Registers metrics for the given executor service with the service's metric registry and
+   * reports them periodically to the configured reporters. Apart from the given tags, the
+   * reporting service's default tags also will be reported with the metrics.
+   *
+   * See https://micrometer.io/docs/ref/jvm for more details on the metrics.
+   */
   public static void monitorExecutorService(String name, ExecutorService executorService,
       @javax.annotation.Nullable Map<String, String> tags) {
     new ExecutorServiceMetrics(executorService, name, addDefaultTags(tags)).bindTo(METER_REGISTRY);

--- a/platform-service-framework/build.gradle.kts
+++ b/platform-service-framework/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     }
   }
 
+  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:3.3.3")
   testImplementation("org.eclipse.jetty:jetty-servlet:9.4.18.v20190429:tests")

--- a/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
+++ b/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
@@ -27,11 +27,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class PlatformService {
+  private static final int DEFAULT_METRIC_REPORT_INTERVAL_SEC = 30;
 
   private static final String METRICS_REPORTER_NAMES_CONFIG_KEY = "metrics.reporter.names";
   private static final String METRICS_REPORTER_PREFIX_CONFIG_KEY = "metrics.reporter.prefix";
-  private static final String METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_CONFIG_KEY =
-      "metrics.reporter.console.reportInterval";
+  private static final String METRICS_REPORT_INTERVAL_CONFIG_KEY = "metrics.reportInterval";
 
   /**
    * List of tags that need to be reported for all the metrics reported by this service.
@@ -41,7 +41,7 @@ public abstract class PlatformService {
    * Please note "app:serviceName" will be reported by default for all metrics, and hence
    * needn't be included in this list.
    */
-  private static final String METRICS_REPORTER_TAGS_CONFIG_KEY = "metrics.reporter.tags";
+  private static final String METRICS_DEFAULT_TAGS_CONFIG_KEY = "metrics.defaultTags";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PlatformService.class);
 
@@ -200,16 +200,14 @@ public abstract class PlatformService {
         .getStringConfig(config, METRICS_REPORTER_PREFIX_CONFIG_KEY,
             PlatformMetricsRegistry.DEFAULT_METRICS_PREFIX);
 
-    int reportInterval = ConfigUtils
-        .getIntConfig(config,
-            METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_CONFIG_KEY,
-            PlatformMetricsRegistry.METRICS_REPORTER_CONSOLE_REPORT_INTERVAL_DEFAULT);
+    int reportIntervalSec = ConfigUtils.getIntConfig(config,
+        METRICS_REPORT_INTERVAL_CONFIG_KEY, DEFAULT_METRIC_REPORT_INTERVAL_SEC);
 
     Map<String, String> tags = new HashMap<>();
 
     // If the metric tags were provided, parse them and pass to the MetricRegistry.
-    if (config.hasPath(METRICS_REPORTER_TAGS_CONFIG_KEY)) {
-      String tagsStr = config.getString(METRICS_REPORTER_TAGS_CONFIG_KEY);
+    if (config.hasPath(METRICS_DEFAULT_TAGS_CONFIG_KEY)) {
+      String tagsStr = config.getString(METRICS_DEFAULT_TAGS_CONFIG_KEY);
       for (List<String> sublist: Lists.partition(Splitter.on(",").splitToList(tagsStr), 2)) {
         if (sublist.size() == 2) {
           tags.put(sublist.get(0), sublist.get(1));
@@ -218,7 +216,7 @@ public abstract class PlatformService {
     }
 
     PlatformMetricsRegistry.initMetricsRegistry(getServiceName(), reporters, metricsPrefix,
-        reportInterval, tags);
+        reportIntervalSec, tags);
   }
 
   enum State {
@@ -230,6 +228,4 @@ public abstract class PlatformService {
     STOPPING,
     STOPPED
   }
-
-
 }

--- a/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
+++ b/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
@@ -205,6 +205,9 @@ public abstract class PlatformService {
 
     Map<String, String> tags = new HashMap<>();
 
+    // Add the service name and other given tags to the default tags list.
+    tags.put("app", getServiceName());
+
     // If the metric tags were provided, parse them and pass to the MetricRegistry.
     if (config.hasPath(METRICS_DEFAULT_TAGS_CONFIG_KEY)) {
       String tagsStr = config.getString(METRICS_DEFAULT_TAGS_CONFIG_KEY);
@@ -215,7 +218,7 @@ public abstract class PlatformService {
       }
     }
 
-    PlatformMetricsRegistry.initMetricsRegistry(getServiceName(), reporters, metricsPrefix,
+    PlatformMetricsRegistry.initMetricsRegistry(reporters, metricsPrefix,
         reportIntervalSec, tags);
   }
 

--- a/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
+++ b/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
@@ -130,8 +130,8 @@ public abstract class PlatformService {
     context.addServlet(new ServletHolder(new CpuProfileServlet()), "/pprof");
     context.addServlet(new ServletHolder(new JVMDiagnosticServlet()), "/diags/*");
 
+    final Thread thread = new Thread(this::doStart);
     try {
-      final Thread thread = new Thread(this::doStart);
       thread.start();
     } catch (Exception e) {
       LOGGER.error("Failed to start thread for application.", e);
@@ -145,6 +145,7 @@ public abstract class PlatformService {
     try {
       adminServer.start();
       LOGGER.info("Started admin service on port: {}.", serviceAdminPort);
+      thread.join();
       adminServer.join();
     } catch (Exception e) {
       LOGGER.error("Failed to start service servlet.");

--- a/platform-service-framework/src/test/java/org/hypertrace/core/serviceframework/PlatformServiceTest.java
+++ b/platform-service-framework/src/test/java/org/hypertrace/core/serviceframework/PlatformServiceTest.java
@@ -1,0 +1,126 @@
+package org.hypertrace.core.serviceframework;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PlatformService}
+ */
+public class PlatformServiceTest {
+  private final CountDownLatch serviceStartSignal = new CountDownLatch(1);
+
+  /**
+   * A test service implementation.
+   */
+  static class TestService extends PlatformService {
+    private final CountDownLatch latch;
+
+    public TestService(ConfigClient client, CountDownLatch latch) {
+      super(client);
+      this.latch = latch;
+    }
+
+    @Override
+    protected void doInit() {
+
+    }
+
+    @Override
+    protected void doStart() {
+      latch.countDown();
+    }
+
+    @Override
+    protected void doStop() {
+
+    }
+
+    @Override
+    public boolean healthCheck() {
+      return true;
+    }
+
+    @Override
+    public String getServiceName() {
+      return "test-service";
+    }
+  }
+
+  @Test
+  public void testMetricInitialization() {
+    PlatformService service = new TestService(new ConfigClient() {
+      @Override
+      public Config getConfig() {
+        return ConfigFactory.parseMap(Map.of("service.admin.port", "59001"));
+      }
+
+      @Override
+      public Config getConfig(String service, String cluster, String pod, String container) {
+        return null;
+      }
+    }, serviceStartSignal);
+
+    // Start the service in a separate thread since the thread which starts it waits until
+    // the service is shutting down.
+    Thread t = new Thread(() -> {
+      service.initialize();
+      service.start();
+    });
+    t.start();
+
+    // Wait for the service to fully start so that admin server is started and all servlets
+    // are initialized.
+    try {
+      serviceStartSignal.await(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Assertions.fail("Waited too long for the service to start.");
+    }
+
+    Assertions.assertEquals("test-service", service.getServiceName());
+    Assertions.assertTrue(service.healthCheck());
+
+    // Verify that the metric registry is initialized and `/metrics` endpoint is working.
+    HttpClient httpclient = HttpClients.createDefault();
+    HttpGet metricsGet = new HttpGet("http://localhost:59001/metrics");
+    try {
+      HttpResponse response = httpclient.execute(metricsGet);
+      Assertions.assertTrue(response.getEntity().getContentType().getValue().startsWith("text/plain;"));
+      String responseStr = EntityUtils.toString(response.getEntity());
+      EntityUtils.consume(response.getEntity());
+
+      // Verify that some key JVM metrics are present in the response.
+      Assertions.assertTrue(responseStr.contains("jvm_memory_used_bytes{app=\"test-service\",area=\"heap\""));
+    } catch (IOException e) {
+      e.printStackTrace();
+      Assertions.fail("Unexpected exception: " + e.getMessage());
+    }
+
+    service.shutdown();
+    try {
+      // Wait for the thread which started the service to go down.
+      t.join();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    // Metrics endpoint should be down now.
+    try {
+      httpclient.execute(metricsGet);
+      Assertions.fail("Expecting an exception here.");
+    } catch (IOException ignore) {
+      // Expected
+    }
+  }
+}


### PR DESCRIPTION
This would let the services to leverage tags support for metrics. For example, we could track request latencies labelled by the tenant id.

**Default tags:**
`app:service-name` will be the default tag that's added for every metric but each service can add more default tags, like the cloud region, az, data center location, etc with the property `metrics.defaultTags`. 
Example: `metrics.defaultTags = az,us-west-1a,region,us-west`

**No more metric prefix:**
Since each metric has `app` label/tag now, metric name itself doesn't need to have the prefix, which is the case right now. This makes it super easy to easily share the Grafana dashboards across the services and also makes the metric names much shorter.

**/metrics for all metrics**
`/metrics` endpoint on the admin server exposes all the metrics, both the MicroMeter based metrics and old Dropwizard based metrics in the Prometheus format by default. No changes needed for all the services to continue using Prom scraper.

**Deprecating the Dropwizard metrics support:**
This commit doesn't remove the Dropwizard metrics support yet but we deprecate it and will eventually remove. All the services will need to start removing their usage of Dropwizard metrics. Another nice thing, we can even get rid of the Flink metrics related special `DropwizardReporter` now.

**Introducing a logging reporter:**
This change also introduces support for `logging` metric reporter, which prints all the metrics to log file. This will be helpful for local debugging or in cases where there is no metrics backend to report to (single node deploy as an example).

Sample log file with the metrics reported:
```java
2020-08-07 10:02:46.363 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.gc.memory.allocated{app=entity-service} throughput=682.666667 KiB/s
2020-08-07 10:02:46.364 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.gc.memory.promoted{app=entity-service} throughput=250.75 KiB/s
2020-08-07 10:02:46.364 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.count{app=entity-service,id=mapped} value=0 buffers
2020-08-07 10:02:46.364 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.count{app=entity-service,id=direct} value=2 buffers
2020-08-07 10:02:46.364 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.count{app=entity-service,id=mapped - 'non-volatile memory'} value=0 buffers
2020-08-07 10:02:46.365 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.memory.used{app=entity-service,id=mapped - 'non-volatile memory'} value=0 B
2020-08-07 10:02:46.365 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.memory.used{app=entity-service,id=mapped} value=0 B
2020-08-07 10:02:46.365 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.memory.used{app=entity-service,id=direct} value=8.000977 KiB
2020-08-07 10:02:46.365 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.total.capacity{app=entity-service,id=direct} value=8 KiB
2020-08-07 10:02:46.365 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.total.capacity{app=entity-service,id=mapped - 'non-volatile memory'} value=0 B
2020-08-07 10:02:46.366 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.buffer.total.capacity{app=entity-service,id=mapped} value=0 B
2020-08-07 10:02:46.366 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.classes.loaded{app=entity-service} value=5317 classes
2020-08-07 10:02:46.366 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.gc.live.data.size{app=entity-service} value=0 B
2020-08-07 10:02:46.367 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.gc.max.data.size{app=entity-service} value=8 GiB
2020-08-07 10:02:46.367 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.memory.committed{app=entity-service,area=heap,id=G1 Old Gen} value=22 MiB
2020-08-07 10:02:46.367 [logging-metrics-publisher] INFO  i.m.c.i.l.LoggingMeterRegistry - jvm.memory.committed{app=entity-service,area=nonheap,id=CodeHeap 'non-profiled nmethods'} value=2.4375 MiB
```

**Testing done:**
Locally modified the entity-service to use this PR and verified that the new metrics, with tags, are reported via both the `/metrics` endpoint and via logging reporter.