### PR TITLE
chore: bump dependencies

### DIFF
--- a/integrationtest-service-framework/build.gradle.kts
+++ b/integrationtest-service-framework/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation(project(":platform-service-framework"))
 
     // Configuration
-    implementation("com.typesafe:config:1.4.0")
+    implementation("com.typesafe:config:1.4.1")
     // Logging
     implementation("org.slf4j:slf4j-api:1.7.30")
     implementation("org.awaitility:awaitility:4.0.3")

--- a/platform-metrics/build.gradle.kts
+++ b/platform-metrics/build.gradle.kts
@@ -10,8 +10,8 @@ tasks.test {
 }
 
 dependencies {
-  api("com.typesafe:config:1.4.0")
-  api("io.dropwizard.metrics:metrics-core:4.1.0")
+  api("com.typesafe:config:1.4.1")
+  api("io.dropwizard.metrics:metrics-core:4.1.16")
   api("io.micrometer:micrometer-core:1.5.3")
   api("org.apache.flink:flink-metrics-core:1.10.1")
   api("org.apache.flink:flink-metrics-prometheus_2.12:1.10.1")
@@ -20,11 +20,11 @@ dependencies {
   implementation("io.micrometer:micrometer-registry-prometheus:1.5.3")
   implementation("io.github.mweirauch:micrometer-jvm-extras:0.2.0")
   implementation("org.slf4j:slf4j-api:1.7.30")
-  implementation("io.dropwizard.metrics:metrics-jvm:4.1.0")
+  implementation("io.dropwizard.metrics:metrics-jvm:4.1.16")
   implementation("io.prometheus:simpleclient_dropwizard:0.6.0")
   implementation("io.prometheus:simpleclient_servlet:0.6.0")
   implementation("io.prometheus:simpleclient_pushgateway:0.9.0")
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.18.v20190429")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.35.v20201120")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:3.3.3")

--- a/platform-service-framework/build.gradle.kts
+++ b/platform-service-framework/build.gradle.kts
@@ -13,12 +13,12 @@ dependencies {
   api(project(":service-framework-spi"))
   implementation(project(":platform-metrics"))
 
-  api("org.slf4j:slf4j-api:1.7.25")
-  api("com.typesafe:config:1.3.2")
+  api("org.slf4j:slf4j-api:1.7.30")
+  api("com.typesafe:config:1.4.1")
 
   // Use for thread dump servlet
-  implementation("io.dropwizard.metrics:metrics-servlets:4.1.0")
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.18.v20190429")
+  implementation("io.dropwizard.metrics:metrics-servlets:4.1.16")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.35.v20201120")
 
   // http client
   implementation("org.apache.httpcomponents:httpclient:4.5.13")


### PR DESCRIPTION
## Description
Update most framework dependencies, including jetty which is flagging https://snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-1047304 across most projects

### Testing
Build and tested the framework project - also updated graphql locally to use the new framework artifact and verified basic functionality.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
