### PR TITLE
chore: discarding printing of entire application config for security

### DIFF
--- a/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
+++ b/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
@@ -94,10 +94,12 @@ public abstract class PlatformService {
     }
     serviceLifecycle.setState(State.INITIALIZING);
 
-    LOGGER.info("Starting the service with this config {}", appConfig);
     Config metricsConfig = appConfig.hasPath(METRICS_CONFIG_KEY) ?
         appConfig.getConfig(METRICS_CONFIG_KEY) : ConfigFactory.empty();
+
+    LOGGER.info("Starting the service by using this metrics configuration {}", metricsConfig);
     PlatformMetricsRegistry.initMetricsRegistry(getServiceName(), metricsConfig);
+
     doInit();
     serviceLifecycle.setState(State.INITIALIZED);
     LOGGER.info("Service - {} is initialized.", getServiceName());


### PR DESCRIPTION
As part of the issue -https://github.com/hypertrace/hypertrace/issues/137, where we identified that some sensitive information is logged (password for postgres), we are going with option (a) listed in the issue. As discussed in the issue, we will let consumers decide on logging in with actionable information.