### PR TITLE
ENG-9598 Adding distribution summary support

### DIFF
--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
@@ -360,8 +360,8 @@ public class PlatformMetricsRegistry {
    * <p>
    * Param histogram – Determines whether percentile histograms should be published.
    * <p>
-   * For more details refer - https://micrometer.io/docs/concepts#_distribution_summaries for more
-   * details, https://micrometer.io/docs/concepts#_histograms_and_percentiles
+   * For more details - https://micrometer.io/docs/concepts#_distribution_summaries,
+   * https://micrometer.io/docs/concepts#_histograms_and_percentiles
    */
   public static DistributionSummary registerDistributionSummary(String name,
       Map<String, String> tags, boolean histogram) {

--- a/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
+++ b/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
@@ -132,7 +132,7 @@ public class PlatformMetricsRegistryTest {
     assertEquals(1, distribution.count());
     assertEquals(100, distribution.totalAmount());
 
-    // Try to register the same timer again and we should get the same instance.
+    // Try to register the same summary again and we should get the same instance.
     distribution = PlatformMetricsRegistry
         .registerDistributionSummary("my.distribution", Map.of("foo", "bar"));
     distribution.record(50);

--- a/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
+++ b/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
@@ -144,12 +144,16 @@ public class PlatformMetricsRegistryTest {
             .collect(
                 Collectors.toList()).containsAll(List.of(0.5, 0.95, 0.99)));
 
-    // Create a new distribution
+    // Create a new distribution with histogram enabled
     distribution = PlatformMetricsRegistry
-        .registerDistributionSummary("my.distribution", new HashMap<>());
+        .registerDistributionSummary("my.distribution", new HashMap<>(), true);
     distribution.record(100);
     assertEquals(1, distribution.count());
     assertEquals(100, distribution.totalAmount());
+    assertTrue(
+        Arrays.stream(distribution.takeSnapshot().percentileValues()).map(m -> m.percentile())
+            .collect(
+                Collectors.toList()).containsAll(List.of(0.5, 0.95, 0.99)));
   }
 
   @Test


### PR DESCRIPTION
Adding support to register distribution summary in PlatformMetricsRegistry

 https://micrometer.io/docs/concepts#_distribution_summaries
