### PR TITLE
ENG 5066: GuavaCacheMetric Support

### DIFF
--- a/platform-metrics/build.gradle.kts
+++ b/platform-metrics/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
   implementation("io.prometheus:simpleclient_servlet:0.6.0")
   implementation("io.prometheus:simpleclient_pushgateway:0.9.0")
   implementation("org.eclipse.jetty:jetty-servlet:9.4.39.v20210325")
+  implementation ("com.google.guava:guava:30.1.1-jre")
+
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
@@ -380,9 +380,8 @@ public class PlatformMetricsRegistry {
    * Registers metrics for GuavaCaches using micrometer's GuavaCacheMetrics under the given
    * cacheName for the given guavaCache
    */
-  public static <K, V> Cache<K, V> registerCache(String cacheName, Cache<K, V> guavaCache) {
-    Cache<K, V> monitor = GuavaCacheMetrics.monitor(METER_REGISTRY, guavaCache, cacheName);
-    return monitor;
+  public static <K, V> void registerCache(String cacheName, Cache<K, V> guavaCache) {
+    GuavaCacheMetrics.monitor(METER_REGISTRY, guavaCache, cacheName);
   }
 
   /**

--- a/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
+++ b/platform-metrics/src/main/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistry.java
@@ -8,22 +8,14 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.JvmAttributeGaugeSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import com.google.common.cache.Cache;
 import com.typesafe.config.Config;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.ImmutableTag;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
-import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
+import io.micrometer.core.instrument.binder.jvm.*;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -38,19 +30,16 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.PushGateway;
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.hypertrace.core.serviceframework.metrics.config.PrometheusPushRegistryConfig;
 import org.hypertrace.core.serviceframework.metrics.registry.PrometheusPushMeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * PlatformMetricsRegistry is the MetricRegistry used for all the metrics. Framework will take care
@@ -73,13 +62,12 @@ public class PlatformMetricsRegistry {
   private static final String CONSOLE_REPORTER_NAME = "console";
 
   /**
-   * List of tags that need to be reported for all the metrics reported by this service.
-   * The tags are given as a list with tag key followed by corresponding value.
-   * Any key without a value will be ignored.
-   * Example: defaultTags = ["k1", "v1", "k2", "v2"]
+   * List of tags that need to be reported for all the metrics reported by this service. The tags
+   * are given as a list with tag key followed by corresponding value. Any key without a value will
+   * be ignored. Example: defaultTags = ["k1", "v1", "k2", "v2"]
    *
-   * Please note "app:serviceName" will be reported by default for all metrics, and hence
-   * needn't be included in this list.
+   * <p>Please note "app:serviceName" will be reported by default for all metrics, and hence needn't
+   * be included in this list.
    */
   private static final String METRICS_DEFAULT_TAGS_CONFIG_KEY = "defaultTags";
 
@@ -87,19 +75,22 @@ public class PlatformMetricsRegistry {
   private static ConsoleReporter consoleReporter;
   private static String metricsPrefix;
   public static final List<String> DEFAULT_METRICS_REPORTERS = List.of("prometheus");
-  private static final Map<String, MetricSet> DEFAULT_METRIC_SET = new HashMap<>() {{
-    put("gc", new GarbageCollectorMetricSet());
-    put("jvm", new JvmAttributeGaugeSet());
-    put("memory", new MemoryUsageGaugeSet());
-    put("thread", new ThreadStatesGaugeSet());
-  }};
+  private static final Map<String, MetricSet> DEFAULT_METRIC_SET =
+      new HashMap<>() {
+        {
+          put("gc", new GarbageCollectorMetricSet());
+          put("jvm", new JvmAttributeGaugeSet());
+          put("memory", new MemoryUsageGaugeSet());
+          put("thread", new ThreadStatesGaugeSet());
+        }
+      };
   private static boolean isInit = false;
   private static final Set<Tag> DEFAULT_TAGS = new HashSet<>();
 
   /**
-   * Main MetricMeter registry, with which all the metrics should be registered. We use
-   * a {@link CompositeMeterRegistry} here so that we can even registry multiple registries
-   * like Prometheus and Logging registries, if needed.
+   * Main MetricMeter registry, with which all the metrics should be registered. We use a {@link
+   * CompositeMeterRegistry} here so that we can even registry multiple registries like Prometheus
+   * and Logging registries, if needed.
    */
   private static final CompositeMeterRegistry METER_REGISTRY = new CompositeMeterRegistry();
 
@@ -107,46 +98,53 @@ public class PlatformMetricsRegistry {
     LOGGER.info("Trying to init PrometheusReporter");
 
     // Add Prometheus registry to the composite registry.
-    METER_REGISTRY.add(new PrometheusMeterRegistry(new PrometheusConfig() {
-      @Override
-      @NonNull
-      public Duration step() {
-        return Duration.ofSeconds(reportInterval);
-      }
+    METER_REGISTRY.add(
+        new PrometheusMeterRegistry(
+            new PrometheusConfig() {
+              @Override
+              @NonNull
+              public Duration step() {
+                return Duration.ofSeconds(reportInterval);
+              }
 
-      @Override
-      @io.micrometer.core.lang.Nullable
-      public String get(String k) {
-        return null;
-      }
-    }, CollectorRegistry.defaultRegistry, Clock.SYSTEM));
+              @Override
+              @io.micrometer.core.lang.Nullable
+              public String get(String k) {
+                return null;
+              }
+            },
+            CollectorRegistry.defaultRegistry,
+            Clock.SYSTEM));
 
     CollectorRegistry.defaultRegistry.register(new DropwizardExports(METRIC_REGISTRY));
   }
 
   private static void initConsoleMetricsReporter(final int reportIntervalSec) {
     consoleReporter = ConsoleReporter.forRegistry(METRIC_REGISTRY).build();
-    LOGGER
-        .info("Trying to init ConsoleReporter with reporter interval=[{}] seconds", reportIntervalSec);
+    LOGGER.info(
+        "Trying to init ConsoleReporter with reporter interval=[{}] seconds", reportIntervalSec);
     consoleReporter.start(reportIntervalSec, TimeUnit.SECONDS);
   }
 
   private static void initLoggingMetricsReporter(int reportIntervalSec) {
     LOGGER.info("Initializing the logging metric reporter.");
 
-    METER_REGISTRY.add(new LoggingMeterRegistry(new LoggingRegistryConfig() {
-      @Override
-      @NonNull
-      public Duration step() {
-        return Duration.ofSeconds(reportIntervalSec);
-      }
+    METER_REGISTRY.add(
+        new LoggingMeterRegistry(
+            new LoggingRegistryConfig() {
+              @Override
+              @NonNull
+              public Duration step() {
+                return Duration.ofSeconds(reportIntervalSec);
+              }
 
-      @Override
-      @io.micrometer.core.lang.Nullable
-      public String get(String key) {
-        return null;
-      }
-    }, Clock.SYSTEM));
+              @Override
+              @io.micrometer.core.lang.Nullable
+              public String get(String key) {
+                return null;
+              }
+            },
+            Clock.SYSTEM));
   }
 
   private static void initTestingMetricsReporter() {
@@ -155,40 +153,45 @@ public class PlatformMetricsRegistry {
     METER_REGISTRY.add(new SimpleMeterRegistry());
   }
 
-  private static void initPrometheusPushGatewayReporter(String serviceName,
-      int reportIntervalSec,
-      String pushUrlAddress) {
-    LOGGER.info("Initializing Prometheus PushGateway Reporter with urlAddress: {}, jobName: {}. "
-        + "Metric is configured get pushed for every {} seconds", pushUrlAddress, serviceName,
+  private static void initPrometheusPushGatewayReporter(
+      String serviceName, int reportIntervalSec, String pushUrlAddress) {
+    LOGGER.info(
+        "Initializing Prometheus PushGateway Reporter with urlAddress: {}, jobName: {}. "
+            + "Metric is configured get pushed for every {} seconds",
+        pushUrlAddress,
+        serviceName,
         reportIntervalSec);
 
     if (pushUrlAddress == null || pushUrlAddress.isEmpty()) {
       throw new IllegalArgumentException("pushUrlAddress configuration is not specified.");
     }
 
-    METER_REGISTRY.add(new PrometheusPushMeterRegistry(
-    new PrometheusPushRegistryConfig() {
-      @Override
-      public String jobName() {
-        return serviceName;
-      }
+    METER_REGISTRY.add(
+        new PrometheusPushMeterRegistry(
+            new PrometheusPushRegistryConfig() {
+              @Override
+              public String jobName() {
+                return serviceName;
+              }
 
-      @Override
-      public String prefix() {
-        return PUSH_GATEWAY_REPORTER_NAME;
-      }
+              @Override
+              public String prefix() {
+                return PUSH_GATEWAY_REPORTER_NAME;
+              }
 
-      @Override
-      @io.micrometer.core.lang.Nullable
-      public String get(String key) {
-        return null;
-      }
+              @Override
+              @io.micrometer.core.lang.Nullable
+              public String get(String key) {
+                return null;
+              }
 
-      @Override
-      public Duration step() {
-        return Duration.ofSeconds(reportIntervalSec);
-      }
-    }, Executors.defaultThreadFactory(), new PushGateway(pushUrlAddress)));
+              @Override
+              public Duration step() {
+                return Duration.ofSeconds(reportIntervalSec);
+              }
+            },
+            Executors.defaultThreadFactory(),
+            new PushGateway(pushUrlAddress)));
   }
 
   private static List<String> getStringList(Config config, String path, List<String> defaultVal) {
@@ -198,15 +201,15 @@ public class PlatformMetricsRegistry {
     return defaultVal;
   }
 
-  public synchronized static void initMetricsRegistry(String serviceName, Config config) {
+  public static synchronized void initMetricsRegistry(String serviceName, Config config) {
     if (isInit) {
       return;
     }
 
     validate(config);
 
-    List<String> reporters = getStringList(config, METRICS_REPORTER_NAMES_CONFIG_KEY,
-        DEFAULT_METRICS_REPORTERS);
+    List<String> reporters =
+        getStringList(config, METRICS_REPORTER_NAMES_CONFIG_KEY, DEFAULT_METRICS_REPORTERS);
 
     metricsPrefix = DEFAULT_METRICS_PREFIX;
     if (config.hasPath(METRICS_REPORTER_PREFIX_CONFIG_KEY)) {
@@ -229,7 +232,8 @@ public class PlatformMetricsRegistry {
       defaultTags.put("app", serviceName);
     }
 
-    List<String> defaultTagsList = getStringList(config, METRICS_DEFAULT_TAGS_CONFIG_KEY, List.of());
+    List<String> defaultTagsList =
+        getStringList(config, METRICS_DEFAULT_TAGS_CONFIG_KEY, List.of());
     for (int i = 0; i + 1 < defaultTagsList.size(); i += 2) {
       defaultTags.put(defaultTagsList.get(i), defaultTagsList.get(i + 1));
     }
@@ -271,15 +275,15 @@ public class PlatformMetricsRegistry {
     new ProcessThreadMetrics().bindTo(METER_REGISTRY);
 
     for (String key : DEFAULT_METRIC_SET.keySet()) {
-      METRIC_REGISTRY
-          .registerAll(String.format("%s.%s", metricsPrefix, key), DEFAULT_METRIC_SET.get(key));
+      METRIC_REGISTRY.registerAll(
+          String.format("%s.%s", metricsPrefix, key), DEFAULT_METRIC_SET.get(key));
     }
     isInit = true;
   }
 
   /**
-   * This method is deprecated since we'll be removing the Dropwizard metrics support in
-   * future releases.
+   * This method is deprecated since we'll be removing the Dropwizard metrics support in future
+   * releases.
    */
   @Deprecated
   public static void register(String metricName, Metric metric) {
@@ -294,7 +298,7 @@ public class PlatformMetricsRegistry {
    * periodically to the configured reporters. Apart from the given tags, the reporting service's
    * default tags also will be reported with the metrics.
    *
-   * See https://micrometer.io/docs/concepts#_counters for more details on the Counter.
+   * <p>See https://micrometer.io/docs/concepts#_counters for more details on the Counter.
    */
   public static Counter registerCounter(String name, Map<String, String> tags) {
     return METER_REGISTRY.counter(name, addDefaultTags(tags));
@@ -305,7 +309,7 @@ public class PlatformMetricsRegistry {
    * and reports it periodically to the configured reporters. Apart from the given tags, the
    * reporting service's default tags also will be reported with the metrics.
    *
-   * See https://micrometer.io/docs/concepts#_timers for more details on the Timer.
+   * <p>See https://micrometer.io/docs/concepts#_timers for more details on the Timer.
    */
   public static Timer registerTimer(String name, Map<String, String> tags) {
     return registerTimer(name, tags, false);
@@ -316,12 +320,11 @@ public class PlatformMetricsRegistry {
    * periodically to the configured reporters. Apart from the given tags, the reporting service's
    * default tags also will be reported with the metrics.
    *
-   * See https://micrometer.io/docs/concepts#_timers for more details on the Timer.
+   * <p>See https://micrometer.io/docs/concepts#_timers for more details on the Timer.
    */
   public static Timer registerTimer(String name, Map<String, String> tags, boolean histogram) {
-    Timer.Builder builder = Timer.builder(name)
-        .publishPercentiles(0.5, 0.95, 0.99)
-        .tags(addDefaultTags(tags));
+    Timer.Builder builder =
+        Timer.builder(name).publishPercentiles(0.5, 0.95, 0.99).tags(addDefaultTags(tags));
     if (histogram) {
       builder = builder.publishPercentileHistogram();
     }
@@ -333,10 +336,14 @@ public class PlatformMetricsRegistry {
    * periodically to the configured reporters. Apart from the given tags, the reporting service's
    * default tags also will be reported with the metrics.
    *
-   * See https://micrometer.io/docs/concepts#_gauges for more details on the Gauges.
+   * <p>See https://micrometer.io/docs/concepts#_gauges for more details on the Gauges.
    */
-  public static <T extends Number> T registerGauge(String name, Map<String, String> tags, T number) {
-    Gauge.builder(name, number, Number::doubleValue).tags(addDefaultTags(tags)).strongReference(true).register(METER_REGISTRY);
+  public static <T extends Number> T registerGauge(
+      String name, Map<String, String> tags, T number) {
+    Gauge.builder(name, number, Number::doubleValue)
+        .tags(addDefaultTags(tags))
+        .strongReference(true)
+        .register(METER_REGISTRY);
     return number;
   }
 
@@ -345,11 +352,11 @@ public class PlatformMetricsRegistry {
    * name with the service's metric registry and reports it periodically to the configured
    * reporters. Apart from the provided tags, the reporting service's default tags also will be
    * reported with the metrics.
-   * <p>
-   * See https://micrometer.io/docs/concepts#_distribution_summaries for more details.
+   *
+   * <p>See https://micrometer.io/docs/concepts#_distribution_summaries for more details.
    */
-  public static DistributionSummary registerDistributionSummary(String name,
-      Map<String, String> tags) {
+  public static DistributionSummary registerDistributionSummary(
+      String name, Map<String, String> tags) {
     return registerDistributionSummary(name, tags, false);
   }
 
@@ -357,17 +364,18 @@ public class PlatformMetricsRegistry {
    * Registers a DistributionSummary for the given name with the service's metric registry and
    * reports it periodically to the configured reporters Apart from the provided tags, the reporting
    * service's default tags also will be reported with the metrics.
-   * <p>
-   * Param histogram – Determines whether percentile histograms should be published.
-   * <p>
-   * For more details - https://micrometer.io/docs/concepts#_distribution_summaries,
+   *
+   * <p>Param histogram – Determines whether percentile histograms should be published.
+   *
+   * <p>For more details - https://micrometer.io/docs/concepts#_distribution_summaries,
    * https://micrometer.io/docs/concepts#_histograms_and_percentiles
    */
-  public static DistributionSummary registerDistributionSummary(String name,
-      Map<String, String> tags, boolean histogram) {
-    DistributionSummary.Builder builder = DistributionSummary.builder(name)
-        .publishPercentiles(0.5, 0.95, 0.99)
-        .tags(addDefaultTags(tags));
+  public static DistributionSummary registerDistributionSummary(
+      String name, Map<String, String> tags, boolean histogram) {
+    DistributionSummary.Builder builder =
+        DistributionSummary.builder(name)
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .tags(addDefaultTags(tags));
     if (histogram) {
       builder = builder.publishPercentileHistogram();
     }
@@ -375,14 +383,23 @@ public class PlatformMetricsRegistry {
   }
 
   /**
-   * Registers metrics for the given executor service with the service's metric registry and
-   * reports them periodically to the configured reporters. Apart from the given tags, the
-   * reporting service's default tags also will be reported with the metrics.
-   *
-   * See https://micrometer.io/docs/ref/jvm for more details on the metrics.
+   * Registers metrics for GuavaCaches using micrometer's GuavaCacheMetrics under the given
+   * cacheName for the given guavaCache
    */
-  public static void monitorExecutorService(String name, ExecutorService executorService,
-      @Nullable Map<String, String> tags) {
+  public static <K, V> Cache<K, V> registerCache(String cacheName, Cache<K, V> guavaCache) {
+    Cache<K, V> monitor = GuavaCacheMetrics.monitor(METER_REGISTRY, guavaCache, cacheName);
+    return monitor;
+  }
+
+  /**
+   * Registers metrics for the given executor service with the service's metric registry and reports
+   * them periodically to the configured reporters. Apart from the given tags, the reporting
+   * service's default tags also will be reported with the metrics.
+   *
+   * <p>See https://micrometer.io/docs/ref/jvm for more details on the metrics.
+   */
+  public static void monitorExecutorService(
+      String name, ExecutorService executorService, @Nullable Map<String, String> tags) {
     new ExecutorServiceMetrics(executorService, name, addDefaultTags(tags)).bindTo(METER_REGISTRY);
   }
 
@@ -421,9 +438,9 @@ public class PlatformMetricsRegistry {
   }
 
   /*
-  * This is needed because ConsoleMetricReporter.stop() doesn't call report for the last time
-  * before closing the scheduled thread
-  */
+   * This is needed because ConsoleMetricReporter.stop() doesn't call report for the last time
+   * before closing the scheduled thread
+   */
   private static void stopConsoleMetricsReporter() {
     if (consoleReporter == null) {
       return;
@@ -435,13 +452,15 @@ public class PlatformMetricsRegistry {
   }
 
   private static void validate(Config config) {
-    List<String> reporters = getStringList(config, METRICS_REPORTER_NAMES_CONFIG_KEY,
-        DEFAULT_METRICS_REPORTERS);
+    List<String> reporters =
+        getStringList(config, METRICS_REPORTER_NAMES_CONFIG_KEY, DEFAULT_METRICS_REPORTERS);
     /* can't contain both prometheus pull and push mechanism */
-    if (reporters.contains(PROMETHEUS_REPORTER_NAME) &&
-        reporters.contains(PUSH_GATEWAY_REPORTER_NAME)) {
-      throw new IllegalArgumentException("Both prometheus and pushgateway are included in the "
-          + METRICS_REPORTER_NAMES_CONFIG_KEY + " configuration. Please choose one of them.");
+    if (reporters.contains(PROMETHEUS_REPORTER_NAME)
+        && reporters.contains(PUSH_GATEWAY_REPORTER_NAME)) {
+      throw new IllegalArgumentException(
+          "Both prometheus and pushgateway are included in the "
+              + METRICS_REPORTER_NAMES_CONFIG_KEY
+              + " configuration. Please choose one of them.");
     }
   }
 }

--- a/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
+++ b/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
@@ -1,5 +1,8 @@
 package org.hypertrace.core.serviceframework.metrics;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.typesafe.config.Config;
@@ -8,10 +11,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -20,9 +19,9 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link PlatformMetricsRegistry} */
 public class PlatformMetricsRegistryTest {
@@ -187,8 +186,7 @@ public class PlatformMetricsRegistryTest {
             return -1;
           }
         };
-
-    // Try catch block for cache.get [Note this doesn't catch the error thrown if assertion fails
+    // Checking cache values
     assertEquals(monitor.get("One", loader), 1);
     cache.put("Two", 2);
     assertEquals(monitor.get("Two", loader), 2);

--- a/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
+++ b/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
@@ -1,39 +1,47 @@
 package org.hypertrace.core.serviceframework.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * Unit tests for {@link PlatformMetricsRegistry}
- */
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link PlatformMetricsRegistry} */
 public class PlatformMetricsRegistryTest {
   private static final String PUSH_GATEWAY_REPORTER_NAME = "pushgateway";
   private static final String PROMETHEUS_REPORTER_NAME = "prometheus";
+
   private static void initializeCustomRegistry(List<String> reporters) {
-    PlatformMetricsRegistry.initMetricsRegistry("test-service",
-        ConfigFactory.parseMap(Map.of(
-            "reporter.names", reporters,
-            "reporter.prefix", "test-service",
-            "reportInterval", "10",
-            "defaultTags", List.of("test.name", "PlatformMetricsRegistryTest")
-        )));
+    PlatformMetricsRegistry.initMetricsRegistry(
+        "test-service",
+        ConfigFactory.parseMap(
+            Map.of(
+                "reporter.names",
+                reporters,
+                "reporter.prefix",
+                "test-service",
+                "reportInterval",
+                "10",
+                "defaultTags",
+                List.of("test.name", "PlatformMetricsRegistryTest"))));
   }
 
   @AfterEach
@@ -62,7 +70,11 @@ public class PlatformMetricsRegistryTest {
     timer.record(1, TimeUnit.SECONDS);
 
     PlatformMetricsRegistry.stop();
-    assertEquals(0, ((CompositeMeterRegistry)PlatformMetricsRegistry.getMeterRegistry()).getRegistries().size());
+    assertEquals(
+        0,
+        ((CompositeMeterRegistry) PlatformMetricsRegistry.getMeterRegistry())
+            .getRegistries()
+            .size());
   }
 
   @Test
@@ -109,15 +121,15 @@ public class PlatformMetricsRegistryTest {
     initializeCustomRegistry(List.of("testing"));
 
     AtomicInteger atomicInteger = new AtomicInteger(1);
-    AtomicInteger gauge = PlatformMetricsRegistry.registerGauge("my.gauge",
-        Map.of("foo", "bar"), atomicInteger);
+    AtomicInteger gauge =
+        PlatformMetricsRegistry.registerGauge("my.gauge", Map.of("foo", "bar"), atomicInteger);
     atomicInteger.incrementAndGet();
     assertEquals(2, gauge.get());
 
     // Register a new instance as a Gauge and the value changes though the tags haven't changed.
     AtomicInteger newAtomicInteger = new AtomicInteger(1);
-    gauge = PlatformMetricsRegistry.registerGauge("my.gauge",
-        Map.of("foo", "bar"), newAtomicInteger);
+    gauge =
+        PlatformMetricsRegistry.registerGauge("my.gauge", Map.of("foo", "bar"), newAtomicInteger);
     newAtomicInteger.addAndGet(10);
     assertEquals(11, gauge.get());
   }
@@ -126,57 +138,98 @@ public class PlatformMetricsRegistryTest {
   public void testDistributionSummary() {
     initializeCustomRegistry(List.of("testing"));
 
-    DistributionSummary distribution = PlatformMetricsRegistry
-        .registerDistributionSummary("my.distribution", Map.of("foo", "bar"));
+    DistributionSummary distribution =
+        PlatformMetricsRegistry.registerDistributionSummary(
+            "my.distribution", Map.of("foo", "bar"));
     distribution.record(100);
     assertEquals(1, distribution.count());
     assertEquals(100, distribution.totalAmount());
 
     // Try to register the same summary again and we should get the same instance.
-    distribution = PlatformMetricsRegistry
-        .registerDistributionSummary("my.distribution", Map.of("foo", "bar"));
+    distribution =
+        PlatformMetricsRegistry.registerDistributionSummary(
+            "my.distribution", Map.of("foo", "bar"));
     distribution.record(50);
     assertEquals(2, distribution.count());
     assertEquals(150, distribution.totalAmount());
     assertEquals(75, distribution.mean());
     assertTrue(
-        Arrays.stream(distribution.takeSnapshot().percentileValues()).map(m -> m.percentile())
-            .collect(
-                Collectors.toList()).containsAll(List.of(0.5, 0.95, 0.99)));
+        Arrays.stream(distribution.takeSnapshot().percentileValues())
+            .map(m -> m.percentile())
+            .collect(Collectors.toList())
+            .containsAll(List.of(0.5, 0.95, 0.99)));
 
     // Create a new distribution with histogram enabled
-    distribution = PlatformMetricsRegistry
-        .registerDistributionSummary("my.distribution", new HashMap<>(), true);
+    distribution =
+        PlatformMetricsRegistry.registerDistributionSummary(
+            "my.distribution", new HashMap<>(), true);
     distribution.record(100);
     assertEquals(1, distribution.count());
     assertEquals(100, distribution.totalAmount());
     assertTrue(
-        Arrays.stream(distribution.takeSnapshot().percentileValues()).map(m -> m.percentile())
-            .collect(
-                Collectors.toList()).containsAll(List.of(0.5, 0.95, 0.99)));
+        Arrays.stream(distribution.takeSnapshot().percentileValues())
+            .map(m -> m.percentile())
+            .collect(Collectors.toList())
+            .containsAll(List.of(0.5, 0.95, 0.99)));
+  }
+
+  @Test
+  public void testCache() throws Exception {
+    initializeCustomRegistry(List.of("testing"));
+
+    Cache<String, Integer> cache = CacheBuilder.newBuilder().maximumSize(10).recordStats().build();
+    cache.put("One", 1);
+    Cache<String, Integer> monitor = PlatformMetricsRegistry.registerCache("my.cache", cache);
+    Callable<Integer> loader =
+        new Callable<Integer>() {
+          @Override
+          public Integer call() throws Exception {
+            return -1;
+          }
+        };
+
+    // Try catch block for cache.get [Note this doesn't catch the error thrown if assertion fails
+    assertEquals(monitor.get("One", loader), 1);
+    cache.put("Two", 2);
+    assertEquals(monitor.get("Two", loader), 2);
+    assertEquals(cache.get("IsNotPresent", loader), -1);
+
+    // Checking cache stats
+    assertEquals(monitor.stats().hitCount(), 2);
+    assertEquals(monitor.stats().missCount(), 1);
+
+    // Registering new cache, values should change
+    Cache<String, Integer> cache1 = CacheBuilder.newBuilder().maximumSize(10).build();
+    monitor = PlatformMetricsRegistry.registerCache("my.cache", cache1);
+    assertEquals(monitor.get("First", loader), -1);
   }
 
   @Test
   public void test_initializePrometheusPushGateway_withNullUrlAddress_throwsException() {
-    Assertions.assertThrows(IllegalArgumentException.class,
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
         () -> initializeCustomRegistry(List.of(PUSH_GATEWAY_REPORTER_NAME)));
   }
 
   @Test
   public void test_init_withBothPromethuesAndPushGateway_throwsException() {
-    Assertions.assertThrows(IllegalArgumentException.class,
-        ()-> initializeCustomRegistry(List.of(PUSH_GATEWAY_REPORTER_NAME, PROMETHEUS_REPORTER_NAME)));
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            initializeCustomRegistry(
+                List.of(PUSH_GATEWAY_REPORTER_NAME, PROMETHEUS_REPORTER_NAME)));
   }
 
   @Test
   public void test_pushMetrics() throws InterruptedException {
-    Config config = ConfigFactory.parseMap(Map.of(
-        "reporter.names", List.of(PUSH_GATEWAY_REPORTER_NAME),
-        "reporter.prefix", "ines-service",
-        "reportInterval", "10",
-        "defaultTags", List.of("test.name", "PlatformMetricsRegistryTest"),
-        "pushUrlAddress", "localhost:9091"
-    ));
+    Config config =
+        ConfigFactory.parseMap(
+            Map.of(
+                "reporter.names", List.of(PUSH_GATEWAY_REPORTER_NAME),
+                "reporter.prefix", "ines-service",
+                "reportInterval", "10",
+                "defaultTags", List.of("test.name", "PlatformMetricsRegistryTest"),
+                "pushUrlAddress", "localhost:9091"));
 
     PlatformMetricsRegistry.initMetricsRegistry("ines-service", config);
     Counter counter = PlatformMetricsRegistry.registerCounter("my.counter", Map.of("foo", "bar"));

--- a/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
+++ b/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
@@ -182,7 +182,11 @@ public class PlatformMetricsRegistryTest {
     cache.get("Two", loader);
     cache.get("Three", loader);
     cache.get("Failed", loader);
-    // expected hit count = 3.0, miss rate = 2.0, cache size = 2 + 2 (misses) = 4.0
+    /*
+    Expected hit count = 3.0, miss rate = 2.0
+    The way cache.get works is that if there is a cache miss then the entry is loaded from the loader and included in the cache,
+    hence the cache size due to the above activity would be 2 (already put One,Two) + 2 (cache miss on Three, Failed) = 4
+     */
 
     // Checking Cache Stats from registry
     double hits = 0, misses = 0,size = 0;

--- a/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
+++ b/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
@@ -27,20 +27,14 @@ import org.junit.jupiter.api.Test;
 public class PlatformMetricsRegistryTest {
   private static final String PUSH_GATEWAY_REPORTER_NAME = "pushgateway";
   private static final String PROMETHEUS_REPORTER_NAME = "prometheus";
-
   private static void initializeCustomRegistry(List<String> reporters) {
-    PlatformMetricsRegistry.initMetricsRegistry(
-        "test-service",
-        ConfigFactory.parseMap(
-            Map.of(
-                "reporter.names",
-                reporters,
-                "reporter.prefix",
-                "test-service",
-                "reportInterval",
-                "10",
-                "defaultTags",
-                List.of("test.name", "PlatformMetricsRegistryTest"))));
+    PlatformMetricsRegistry.initMetricsRegistry("test-service",
+        ConfigFactory.parseMap(Map.of(
+            "reporter.names", reporters,
+            "reporter.prefix", "test-service",
+            "reportInterval", "10",
+            "defaultTags", List.of("test.name", "PlatformMetricsRegistryTest")
+        )));
   }
 
   @AfterEach
@@ -69,11 +63,7 @@ public class PlatformMetricsRegistryTest {
     timer.record(1, TimeUnit.SECONDS);
 
     PlatformMetricsRegistry.stop();
-    assertEquals(
-        0,
-        ((CompositeMeterRegistry) PlatformMetricsRegistry.getMeterRegistry())
-            .getRegistries()
-            .size());
+    assertEquals(0, ((CompositeMeterRegistry)PlatformMetricsRegistry.getMeterRegistry()).getRegistries().size());
   }
 
   @Test
@@ -120,15 +110,15 @@ public class PlatformMetricsRegistryTest {
     initializeCustomRegistry(List.of("testing"));
 
     AtomicInteger atomicInteger = new AtomicInteger(1);
-    AtomicInteger gauge =
-        PlatformMetricsRegistry.registerGauge("my.gauge", Map.of("foo", "bar"), atomicInteger);
+    AtomicInteger gauge = PlatformMetricsRegistry.registerGauge("my.gauge",
+        Map.of("foo", "bar"), atomicInteger);
     atomicInteger.incrementAndGet();
     assertEquals(2, gauge.get());
 
     // Register a new instance as a Gauge and the value changes though the tags haven't changed.
     AtomicInteger newAtomicInteger = new AtomicInteger(1);
-    gauge =
-        PlatformMetricsRegistry.registerGauge("my.gauge", Map.of("foo", "bar"), newAtomicInteger);
+    gauge = PlatformMetricsRegistry.registerGauge("my.gauge",
+        Map.of("foo", "bar"), newAtomicInteger);
     newAtomicInteger.addAndGet(10);
     assertEquals(11, gauge.get());
   }
@@ -137,31 +127,27 @@ public class PlatformMetricsRegistryTest {
   public void testDistributionSummary() {
     initializeCustomRegistry(List.of("testing"));
 
-    DistributionSummary distribution =
-        PlatformMetricsRegistry.registerDistributionSummary(
-            "my.distribution", Map.of("foo", "bar"));
+    DistributionSummary distribution = PlatformMetricsRegistry
+        .registerDistributionSummary("my.distribution", Map.of("foo", "bar"));
     distribution.record(100);
     assertEquals(1, distribution.count());
     assertEquals(100, distribution.totalAmount());
 
     // Try to register the same summary again and we should get the same instance.
-    distribution =
-        PlatformMetricsRegistry.registerDistributionSummary(
-            "my.distribution", Map.of("foo", "bar"));
+    distribution = PlatformMetricsRegistry
+        .registerDistributionSummary("my.distribution", Map.of("foo", "bar"));
     distribution.record(50);
     assertEquals(2, distribution.count());
     assertEquals(150, distribution.totalAmount());
     assertEquals(75, distribution.mean());
     assertTrue(
-        Arrays.stream(distribution.takeSnapshot().percentileValues())
-            .map(m -> m.percentile())
-            .collect(Collectors.toList())
-            .containsAll(List.of(0.5, 0.95, 0.99)));
+        Arrays.stream(distribution.takeSnapshot().percentileValues()).map(m -> m.percentile())
+            .collect(
+                Collectors.toList()).containsAll(List.of(0.5, 0.95, 0.99)));
 
     // Create a new distribution with histogram enabled
-    distribution =
-        PlatformMetricsRegistry.registerDistributionSummary(
-            "my.distribution", new HashMap<>(), true);
+    distribution = PlatformMetricsRegistry
+        .registerDistributionSummary("my.distribution", new HashMap<>(), true);
     distribution.record(100);
     assertEquals(1, distribution.count());
     assertEquals(100, distribution.totalAmount());
@@ -204,30 +190,25 @@ public class PlatformMetricsRegistryTest {
 
   @Test
   public void test_initializePrometheusPushGateway_withNullUrlAddress_throwsException() {
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
+    Assertions.assertThrows(IllegalArgumentException.class,
         () -> initializeCustomRegistry(List.of(PUSH_GATEWAY_REPORTER_NAME)));
   }
 
   @Test
   public void test_init_withBothPromethuesAndPushGateway_throwsException() {
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            initializeCustomRegistry(
-                List.of(PUSH_GATEWAY_REPORTER_NAME, PROMETHEUS_REPORTER_NAME)));
+    Assertions.assertThrows(IllegalArgumentException.class,
+        ()-> initializeCustomRegistry(List.of(PUSH_GATEWAY_REPORTER_NAME, PROMETHEUS_REPORTER_NAME)));
   }
 
   @Test
   public void test_pushMetrics() throws InterruptedException {
-    Config config =
-        ConfigFactory.parseMap(
-            Map.of(
-                "reporter.names", List.of(PUSH_GATEWAY_REPORTER_NAME),
-                "reporter.prefix", "ines-service",
-                "reportInterval", "10",
-                "defaultTags", List.of("test.name", "PlatformMetricsRegistryTest"),
-                "pushUrlAddress", "localhost:9091"));
+    Config config = ConfigFactory.parseMap(Map.of(
+        "reporter.names", List.of(PUSH_GATEWAY_REPORTER_NAME),
+        "reporter.prefix", "ines-service",
+        "reportInterval", "10",
+        "defaultTags", List.of("test.name", "PlatformMetricsRegistryTest"),
+        "pushUrlAddress", "localhost:9091"
+    ));
 
     PlatformMetricsRegistry.initMetricsRegistry("ines-service", config);
     Counter counter = PlatformMetricsRegistry.registerCounter("my.counter", Map.of("foo", "bar"));

--- a/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
+++ b/platform-metrics/src/test/java/org/hypertrace/core/serviceframework/metrics/PlatformMetricsRegistryTest.java
@@ -9,7 +9,6 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.Arrays;
@@ -187,7 +186,6 @@ public class PlatformMetricsRegistryTest {
 
     // Checking Cache Stats from registry
     double hits = 0, misses = 0,size = 0;
-    List<Meter> meterList = PlatformMetricsRegistry.getMeterRegistry().getMeters();
     // Fetching the hits, misses registered in the registry by browsing through all the registered
     // meters
     hits = PlatformMetricsRegistry.getMeterRegistry().get("cache.gets").tag("result","hit").meter().measure().iterator().next().getValue();


### PR DESCRIPTION
## Description
Implemented GuavaCache Metric Support (registerCache) which registers cache metrics with the Metric Registry. 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Test includes testCache, which tests the cache values, cacheStats and if monitoring cache is changing when another cache is registered.
### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
