### PR TITLE
chore: update codecov gha to v2

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -34,7 +34,7 @@ jobs:
           args: jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: unit test reports
           fail_ci_if_error: true

--- a/platform-service-framework/build.gradle.kts
+++ b/platform-service-framework/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   api("com.typesafe:config:1.4.1")
 
   // Use for thread dump servlet
-  implementation("io.dropwizard.metrics:metrics-servlets:4.1.16")
+  implementation("io.dropwizard.metrics:metrics-servlets:4.2.8")
   implementation("org.eclipse.jetty:jetty-servlet:9.4.44.v20210927")
 
   // Use for metrics servlet
@@ -27,9 +27,6 @@ dependencies {
   implementation("org.apache.httpcomponents:httpclient:4.5.13")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2") {
-      because("Multiple vulnerabilities")
-    }
     implementation("commons-codec:commons-codec:1.15") {
       because("version 1.12 has a vulnerability https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518")
     }


### PR DESCRIPTION
## Description
Codecov bash uploader is being deprecated and is currently in the brownout phase. We need to upgrade to the v2 gh action in all repos.

More info: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/
