### PR TITLE
Int test fixes

### DIFF
--- a/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClient.java
+++ b/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClient.java
@@ -2,37 +2,42 @@ package org.hypertrace.core.serviceframework.config;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
- * Config client used for integration tests to load the config from the
- * {@link #resourcePrefix}/application.conf file that's present in the classpath.
+ * Config client used for integration tests to load the config from the {@link
+ * #resourcePrefix}/application.conf file that's present in the classpath.
  */
 public class IntegrationTestConfigClient implements ConfigClient {
-  private static final String APPLICATION_CONFIG_FILE = "application.conf";
-  private static final String INTEGRATION_TEST_COMMON_PREFIX = "configs/common";
-  private static final String INTEGRATION_TEST_ENV = "local";
+  private static final String APPLICATION_CONFIG_FILE_SUFFIX = "/application.conf";
+  private static final String CONFIGS_PREFIX = "configs/";
+  private static final String INTEGRATION_TEST_COMMON_DIRECTORY = "common";
+  private static final String INTEGRATION_TEST_CLUSTER = "local";
 
+  private final String defaultServiceName;
 
-  private final String resourcePrefix;
-
-  public IntegrationTestConfigClient(String resourcePrefix) {
-    this.resourcePrefix = resourcePrefix;
+  public IntegrationTestConfigClient(String defaultServiceName) {
+    this.defaultServiceName = defaultServiceName;
   }
 
   @Override
   public Config getConfig() {
-    Config config = ConfigFactory.parseResources(resourcePrefix + "/" + APPLICATION_CONFIG_FILE);
-    Config commonConfig = ConfigFactory.parseResources(
-        String.format("%s/%s", INTEGRATION_TEST_COMMON_PREFIX, APPLICATION_CONFIG_FILE));
-    Config localConfig = ConfigFactory.parseResources(resourcePrefix + "/" + INTEGRATION_TEST_ENV
-        + "/" + APPLICATION_CONFIG_FILE);
-    return localConfig.withFallback(config).withFallback(commonConfig).resolve();
+    return this.getConfig(this.defaultServiceName, INTEGRATION_TEST_CLUSTER, null, null);
   }
 
   @Override
   public Config getConfig(String service, String cluster, String pod, String container) {
-    throw new UnsupportedOperationException(
-        "Loads from configs/application.conf. "
-            + "Doesn't support different hierarchy of configurations");
+    return loadConfig(service, cluster, pod, container)
+        .withFallback(loadConfig(service, cluster, pod))
+        .withFallback(loadConfig(service, cluster))
+        .withFallback(loadConfig(service))
+        .withFallback(loadConfig(INTEGRATION_TEST_COMMON_DIRECTORY));
+  }
+
+  private Config loadConfig(String... segments) {
+    return ConfigFactory.parseResources(
+        Arrays.stream(segments)
+            .collect(Collectors.joining("/", CONFIGS_PREFIX, APPLICATION_CONFIG_FILE_SUFFIX)));
   }
 }

--- a/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClient.java
+++ b/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClient.java
@@ -32,7 +32,8 @@ public class IntegrationTestConfigClient implements ConfigClient {
         .withFallback(loadConfig(service, cluster, pod))
         .withFallback(loadConfig(service, cluster))
         .withFallback(loadConfig(service))
-        .withFallback(loadConfig(INTEGRATION_TEST_COMMON_DIRECTORY));
+        .withFallback(loadConfig(INTEGRATION_TEST_COMMON_DIRECTORY))
+        .resolve();
   }
 
   private Config loadConfig(String... segments) {

--- a/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClientFactory.java
+++ b/integrationtest-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/IntegrationTestConfigClientFactory.java
@@ -8,8 +8,7 @@ import org.hypertrace.core.serviceframework.IntegrationTestServiceLauncher;
  * Config is loaded from resources/config/application.conf
  */
 public class IntegrationTestConfigClientFactory {
-  public static synchronized ConfigClient getConfigClientForService(String serviceName) {
-    String resourcePrefix = "configs" + "/" + serviceName;
-    return new IntegrationTestConfigClient(resourcePrefix);
+  public static ConfigClient getConfigClientForService(String serviceName) {
+    return new IntegrationTestConfigClient(serviceName);
   }
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcServiceContainerEnvironment.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcServiceContainerEnvironment.java
@@ -21,11 +21,7 @@ class ConsolidatedGrpcServiceContainerEnvironment implements GrpcServiceContaine
 
   @Override
   public Config getConfig(String serviceName) {
-    return ConfigClientFactory.getClient(
-            ConsolidatedGrpcServiceContainerEnvironment.class
-                .getClassLoader()
-                .getResource("configs/" + serviceName)
-                .toExternalForm())
+    return ConfigClientFactory.getClientForService(serviceName)
         .getConfig("consolidated", "helm-overrides", null, null);
   }
 }

--- a/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/ConfigClientFactory.java
+++ b/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/config/ConfigClientFactory.java
@@ -10,8 +10,7 @@ public class ConfigClientFactory {
 
   private static Map<String, ConfigClient> configClientMap = new HashMap<>();
 
-  private ConfigClientFactory() {
-  }
+  private ConfigClientFactory() {}
 
   public static synchronized ConfigClient getClient() {
     String bootstrapUri = ConfigUtils.getEnvironmentProperty("bootstrap.config.uri");
@@ -42,10 +41,18 @@ public class ConfigClientFactory {
                 "Not yet supported ConfigClient bootstrap URI scheme: " + scheme);
         }
       } catch (URISyntaxException e) {
-        throw new RuntimeException("Failed to init ConfigClient with a bad URI: " + bootstrapUri,
-            e);
+        throw new RuntimeException(
+            "Failed to init ConfigClient with a bad URI: " + bootstrapUri, e);
       }
     }
     return configClientMap.get(bootstrapUri);
+  }
+
+  public static ConfigClient getClientForService(String serviceName) {
+    return getClient(
+        ConfigClientFactory.class
+            .getClassLoader()
+            .getResource("configs/" + serviceName)
+            .toExternalForm());
   }
 }


### PR DESCRIPTION
## Description
The new grpc service factory container classes don't rely on environment variables for things like cluster (which were unused, and thus call the direct getConfig(x,y,z) method. This was unsupported for integration tests, so refactored to support both the prior and new styles.

### Testing
Verified integration tests both in old service that hasn't been changed for backwards compat, and new service using the new grpc service factory style.
