### PR TITLE
refactor: expose type of channel registry, in process name

### DIFF
--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcPlatformServiceContainer.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
 
@@ -28,8 +27,9 @@ public abstract class ConsolidatedGrpcPlatformServiceContainer
 
   @Override
   protected GrpcServiceContainerEnvironment buildContainerEnvironment(
-      GrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager) {
-    return new ConsolidatedGrpcServiceContainerEnvironment(channelRegistry, healthStatusManager);
+      InProcessGrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager) {
+    return new ConsolidatedGrpcServiceContainerEnvironment(
+        channelRegistry, healthStatusManager, this.getInProcessServerName());
   }
 
   protected Collection<String> getAuthoritiesToTreatAsInProcess() {

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcServiceContainerEnvironment.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcServiceContainerEnvironment.java
@@ -5,14 +5,16 @@ import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.protobuf.services.HealthStatusManager;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
 
 @AllArgsConstructor
 class ConsolidatedGrpcServiceContainerEnvironment implements GrpcServiceContainerEnvironment {
 
-  @Getter private final GrpcChannelRegistry channelRegistry;
+  @Getter private final InProcessGrpcChannelRegistry channelRegistry;
   private final HealthStatusManager healthStatusManager;
+
+  @Getter private final String inProcessChannelName;
 
   @Override
   public void reportServiceStatus(String serviceName, ServingStatus status) {

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -15,7 +15,6 @@ import io.grpc.protobuf.services.HealthStatusManager;
 import java.io.IOException;
 import java.util.Collection;
 import lombok.extern.slf4j.Slf4j;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.grpcutils.server.InterceptorUtil;
 import org.hypertrace.core.grpcutils.server.ServerManagementUtil;
@@ -118,5 +117,5 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
   protected abstract Collection<GrpcPlatformServiceFactory> getServiceFactories();
 
   protected abstract GrpcServiceContainerEnvironment buildContainerEnvironment(
-      GrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager);
+      InProcessGrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager);
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcServiceContainerEnvironment.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcServiceContainerEnvironment.java
@@ -2,12 +2,14 @@ package org.hypertrace.core.serviceframework.grpc;
 
 import com.typesafe.config.Config;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 
 public interface GrpcServiceContainerEnvironment {
-  GrpcChannelRegistry getChannelRegistry();
+  InProcessGrpcChannelRegistry getChannelRegistry();
 
   void reportServiceStatus(String serviceName, ServingStatus status);
 
   Config getConfig(String serviceName);
+
+  String getInProcessChannelName();
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcPlatformServiceContainer.java
@@ -4,7 +4,7 @@ import io.grpc.protobuf.services.HealthStatusManager;
 import java.util.Collection;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
 
 @Slf4j
@@ -22,8 +22,8 @@ public abstract class StandAloneGrpcPlatformServiceContainer extends GrpcPlatfor
 
   @Override
   protected GrpcServiceContainerEnvironment buildContainerEnvironment(
-      GrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager) {
+      InProcessGrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager) {
     return new StandAloneGrpcServiceContainerEnvironment(
-        channelRegistry, healthStatusManager, this.configClient);
+        channelRegistry, healthStatusManager, this.configClient, this.getInProcessServerName());
   }
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcServiceContainerEnvironment.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcServiceContainerEnvironment.java
@@ -5,16 +5,18 @@ import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.protobuf.services.HealthStatusManager;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
 
 @AllArgsConstructor
 public class StandAloneGrpcServiceContainerEnvironment implements GrpcServiceContainerEnvironment {
 
-  @Getter private final GrpcChannelRegistry channelRegistry;
+  @Getter private final InProcessGrpcChannelRegistry channelRegistry;
   private final HealthStatusManager healthStatusManager;
 
   private final ConfigClient configClient;
+
+  @Getter private final String inProcessChannelName;
 
   @Override
   public void reportServiceStatus(String serviceName, ServingStatus status) {


### PR DESCRIPTION
## Description
Expose more details about existing in process transport to allow services to use in process transport if they choose to.