### PR TITLE
feat: add support for multiple grpc servers, scheduled tasks

### DIFF
--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcPlatformServiceContainer.java
@@ -38,7 +38,9 @@ public abstract class ConsolidatedGrpcPlatformServiceContainer
   protected List<GrpcPlatformServerDefinition> getServerDefinitions() {
     return List.of(
         new GrpcPlatformServerDefinition(
-            this.getServiceName(), this.getServicePort(), this.getServiceFactories()));
+            "networked-" + this.getServiceName(),
+            this.getServicePort(),
+            this.getServiceFactories()));
   }
 
   /**

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/ConsolidatedGrpcPlatformServiceContainer.java
@@ -3,6 +3,7 @@ package org.hypertrace.core.serviceframework.grpc;
 import io.grpc.protobuf.services.HealthStatusManager;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -14,6 +15,7 @@ import org.hypertrace.core.serviceframework.config.ConfigClient;
 public abstract class ConsolidatedGrpcPlatformServiceContainer
     extends GrpcPlatformServiceContainer {
   private static final String AUTHORITY_OVERRIDE_PATH = "service.authorities";
+  private static final String DEFAULT_PORT_PATH = "service.port";
 
   public ConsolidatedGrpcPlatformServiceContainer(ConfigClient configClient) {
     super(configClient);
@@ -30,6 +32,26 @@ public abstract class ConsolidatedGrpcPlatformServiceContainer
       InProcessGrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager) {
     return new ConsolidatedGrpcServiceContainerEnvironment(
         channelRegistry, healthStatusManager, this.getInProcessServerName());
+  }
+
+  @Override
+  protected List<GrpcPlatformServerDefinition> getServerDefinitions() {
+    return List.of(
+        new GrpcPlatformServerDefinition(
+            this.getServiceName(), this.getServicePort(), this.getServiceFactories()));
+  }
+
+  /**
+   * @deprecated - implement {@link #getServerDefinitions()}} instead
+   */
+  @Deprecated
+  protected Collection<GrpcPlatformServiceFactory> getServiceFactories() {
+    return Collections.emptySet();
+  }
+
+  @Deprecated
+  protected int getServicePort() {
+    return this.getAppConfig().getInt(DEFAULT_PORT_PATH);
   }
 
   protected Collection<String> getAuthoritiesToTreatAsInProcess() {

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServerDefinition.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServerDefinition.java
@@ -1,0 +1,15 @@
+package org.hypertrace.core.serviceframework.grpc;
+
+import java.util.Collection;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+
+@Value
+@Builder
+public class GrpcPlatformServerDefinition {
+  String name;
+  int port;
+  @Singular
+  Collection<GrpcPlatformServiceFactory> serviceFactories;
+}

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -1,9 +1,9 @@
 package org.hypertrace.core.serviceframework.grpc;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static io.grpc.Deadline.after;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import io.grpc.Deadline;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.health.v1.HealthCheckRequest;
@@ -14,18 +14,31 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.protobuf.services.HealthStatusManager;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.grpcutils.server.InterceptorUtil;
 import org.hypertrace.core.grpcutils.server.ServerManagementUtil;
 import org.hypertrace.core.serviceframework.PlatformService;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
+import org.hypertrace.core.serviceframework.spi.PlatformServiceLifecycle.State;
 
 @Slf4j
 abstract class GrpcPlatformServiceContainer extends PlatformService {
-  private static final String DEFAULT_PORT_PATH = "service.port";
-  private Server networkedServer;
-  private Server inProcessServer;
+
+  private List<ConstructedServer> servers;
+  private final List<PlatformPeriodicTaskDefinition> taskDefinitions = new LinkedList<>();
+  private final List<ScheduledFuture<?>> scheduledFutures = new LinkedList<>();
+  private ScheduledExecutorService periodicTaskExecutor;
 
   private final HealthStatusManager healthStatusManager = new HealthStatusManager();
   private InProcessGrpcChannelRegistry grpcChannelRegistry;
@@ -38,53 +51,99 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
   @Override
   protected void doInit() {
     this.grpcChannelRegistry = this.buildChannelRegistry();
-    final ServerBuilder<?> networkedServerBuilder = ServerBuilder.forPort(this.getServicePort());
+    Map<GrpcPlatformServerDefinition, ServerBuilder<?>> serverBuilderMap =
+        this.getServerDefinitions().stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    Function.identity(),
+                    definition -> ServerBuilder.forPort(definition.getPort())));
     final ServerBuilder<?> inProcessServerBuilder =
-        InProcessServerBuilder.forName(this.getInProcessServerName());
+        InProcessServerBuilder.forName(this.getInProcessServerName())
+            .addService(this.healthStatusManager.getHealthService());
     final GrpcServiceContainerEnvironment serviceContainerEnvironment =
         this.buildContainerEnvironment(this.grpcChannelRegistry, this.healthStatusManager);
-    this.getServiceFactories().stream()
-        .map(factory -> factory.buildServices(serviceContainerEnvironment))
+    this.servers =
+        serverBuilderMap.entrySet().stream()
+            .map(
+                entry ->
+                    this.constructServer(
+                        entry.getKey(),
+                        entry.getValue(),
+                        inProcessServerBuilder,
+                        serviceContainerEnvironment))
+            .collect(Collectors.toUnmodifiableList());
+    this.healthClient =
+        HealthGrpc.newBlockingStub(this.grpcChannelRegistry.forName(this.getInProcessServerName()));
+  }
+
+  private ConstructedServer constructServer(
+      GrpcPlatformServerDefinition serverDefinition,
+      ServerBuilder<?> networkedBuilder,
+      ServerBuilder<?> inProcessServerBuilder,
+      GrpcServiceContainerEnvironment containerEnvironment) {
+    serverDefinition.getServiceFactories().stream()
+        .map(factory -> factory.buildServices(containerEnvironment))
         .flatMap(Collection::stream)
         .map(GrpcPlatformService::getGrpcService)
         .map(InterceptorUtil::wrapInterceptors)
         .forEach(
             service -> {
-              networkedServerBuilder.addService(service);
+              networkedBuilder.addService(service);
               inProcessServerBuilder.addService(service);
             });
-    inProcessServerBuilder.addService(this.healthStatusManager.getHealthService());
-    this.networkedServer = networkedServerBuilder.build();
-    this.inProcessServer = inProcessServerBuilder.build();
-    this.healthClient =
-        HealthGrpc.newBlockingStub(this.grpcChannelRegistry.forName(this.getInProcessServerName()));
+
+    return new ConstructedServer(serverDefinition.getName(), networkedBuilder.build());
   }
 
   @Override
   protected void doStart() {
     log.info("Starting: {}", getServiceName());
+    this.startManagedPeriodicTasks();
+    this.servers.stream().map(ConstructedServer::getServer).forEach(this::startServer);
+    this.servers.stream().map(ConstructedServer::getServer).forEach(this::awaitServerTermination);
+  }
+
+  private void startManagedPeriodicTasks() {
+    this.periodicTaskExecutor = this.buildTaskExecutor(this.taskDefinitions.size());
+    this.taskDefinitions.forEach(this::startManagedPeriodicTask);
+  }
+
+  private void startManagedPeriodicTask(PlatformPeriodicTaskDefinition taskDefinition) {
+    this.scheduledFutures.add(
+        this.periodicTaskExecutor.scheduleAtFixedRate(
+            taskDefinition.getRunnable(),
+            taskDefinition.getInitialDelay().toMillis(),
+            taskDefinition.getPeriod().toMillis(),
+            MILLISECONDS));
+  }
+
+  private void startServer(Server server) {
     try {
-      this.inProcessServer.start();
-      this.networkedServer.start();
-      this.networkedServer.awaitTermination();
-      this.inProcessServer.awaitTermination();
+      server.start();
     } catch (IOException e) {
       log.error("Fail to start the server.");
       throw new RuntimeException(e);
-    } catch (InterruptedException ie) {
+    }
+  }
+
+  private void awaitServerTermination(Server server) {
+    try {
+      server.awaitTermination();
+    } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException(ie);
+      throw new RuntimeException(e);
     }
   }
 
   @Override
   protected void doStop() {
+    this.scheduledFutures.forEach(future -> future.cancel(true));
     healthStatusManager.enterTerminalState();
-    grpcChannelRegistry.shutdown(Deadline.after(10, SECONDS));
-    ServerManagementUtil.shutdownServer(
-        this.networkedServer, "networked:" + this.getServiceName(), Deadline.after(1, MINUTES));
-    ServerManagementUtil.shutdownServer(
-        this.inProcessServer, "inprocess:" + this.getServiceName(), Deadline.after(1, MINUTES));
+    grpcChannelRegistry.shutdown(after(10, SECONDS));
+    this.servers.forEach(
+        constructedServer ->
+            ServerManagementUtil.shutdownServer(
+                constructedServer.getServer(), constructedServer.getName(), after(30, SECONDS)));
   }
 
   @Override
@@ -101,10 +160,6 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
     }
   }
 
-  protected int getServicePort() {
-    return this.getAppConfig().getInt(DEFAULT_PORT_PATH);
-  }
-
   protected InProcessGrpcChannelRegistry buildChannelRegistry() {
     return new InProcessGrpcChannelRegistry();
   }
@@ -113,8 +168,32 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
     return this.getServiceName();
   }
 
-  protected abstract Collection<GrpcPlatformServiceFactory> getServiceFactories();
+  protected ScheduledExecutorService buildTaskExecutor(int taskCount) {
+    // Between 1-4 threads
+    return Executors.newScheduledThreadPool(Math.max(1, Math.min(taskCount, 4)));
+  }
+
+  protected void registerManagedPeriodicTask(PlatformPeriodicTaskDefinition periodicTask) {
+    if (State.STARTED.compareTo(this.getServiceState()) > 0) {
+      // Not yet started, just queue it
+      this.taskDefinitions.add(periodicTask);
+    } else if (State.STARTED.equals(this.getServiceState())) {
+      // Already started so just start it immediately instead of queueing it
+      this.startManagedPeriodicTask(periodicTask);
+    } else {
+      throw new UnsupportedOperationException(
+          "Cannot register period task for server at state: " + this.getServiceState().name());
+    }
+  }
+
+  protected abstract List<GrpcPlatformServerDefinition> getServerDefinitions();
 
   protected abstract GrpcServiceContainerEnvironment buildContainerEnvironment(
       InProcessGrpcChannelRegistry channelRegistry, HealthStatusManager healthStatusManager);
+
+  @Value
+  private static class ConstructedServer {
+    String name;
+    Server server;
+  }
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -127,6 +127,7 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
   private void startManagedPeriodicTasks() {
     this.periodicTaskExecutor = this.buildTaskExecutor(this.taskDefinitions.size());
     this.taskDefinitions.forEach(this::startManagedPeriodicTask);
+    this.taskDefinitions.clear();
   }
 
   private void startManagedPeriodicTask(PlatformPeriodicTaskDefinition taskDefinition) {

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/PlatformPeriodicTaskDefinition.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/PlatformPeriodicTaskDefinition.java
@@ -1,0 +1,13 @@
+package org.hypertrace.core.serviceframework.grpc;
+
+import java.time.Duration;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class PlatformPeriodicTaskDefinition {
+  Runnable runnable;
+  Duration initialDelay;
+  Duration period;
+}

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/PlatformPeriodicTaskDefinition.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/PlatformPeriodicTaskDefinition.java
@@ -10,4 +10,5 @@ public class PlatformPeriodicTaskDefinition {
   Runnable runnable;
   Duration initialDelay;
   Duration period;
+  String name;
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcPlatformServiceContainer.java
@@ -31,7 +31,9 @@ public abstract class StandAloneGrpcPlatformServiceContainer extends GrpcPlatfor
   protected List<GrpcPlatformServerDefinition> getServerDefinitions() {
     return List.of(
         new GrpcPlatformServerDefinition(
-            this.getServiceName(), this.getServicePort(), Set.of(this.getServiceFactory())));
+            "networked-" + this.getServiceName(),
+            this.getServicePort(),
+            Set.of(this.getServiceFactory())));
   }
 
   @Override

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcPlatformServiceContainer.java
@@ -1,7 +1,7 @@
 package org.hypertrace.core.serviceframework.grpc;
 
 import io.grpc.protobuf.services.HealthStatusManager;
-import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
@@ -9,15 +9,29 @@ import org.hypertrace.core.serviceframework.config.ConfigClient;
 
 @Slf4j
 public abstract class StandAloneGrpcPlatformServiceContainer extends GrpcPlatformServiceContainer {
+  protected static final String DEFAULT_PORT_PATH = "service.port";
+
   public StandAloneGrpcPlatformServiceContainer(ConfigClient configClient) {
     super(configClient);
   }
 
-  protected abstract GrpcPlatformServiceFactory getServiceFactory();
+  /**
+   * @deprecated implement {@link #getServerDefinitions()} instead
+   */
+  @Deprecated
+  protected GrpcPlatformServiceFactory getServiceFactory() {
+    throw new UnsupportedOperationException(
+        "getServiceFactory not implemented. Implement and use getServerDefinitions instead");
+  }
 
-  @Override
-  protected final Collection<GrpcPlatformServiceFactory> getServiceFactories() {
-    return Set.of(this.getServiceFactory());
+  protected int getServicePort() {
+    return this.getAppConfig().getInt(DEFAULT_PORT_PATH);
+  }
+
+  protected List<GrpcPlatformServerDefinition> getServerDefinitions() {
+    return List.of(
+        new GrpcPlatformServerDefinition(
+            this.getServiceName(), this.getServicePort(), Set.of(this.getServiceFactory())));
   }
 
   @Override

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcServiceContainerEnvironment.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/StandAloneGrpcServiceContainerEnvironment.java
@@ -9,7 +9,7 @@ import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
 
 @AllArgsConstructor
-public class StandAloneGrpcServiceContainerEnvironment implements GrpcServiceContainerEnvironment {
+class StandAloneGrpcServiceContainerEnvironment implements GrpcServiceContainerEnvironment {
 
   @Getter private final InProcessGrpcChannelRegistry channelRegistry;
   private final HealthStatusManager healthStatusManager;


### PR DESCRIPTION
## Description
This PR adds support for more common patterns shared amongst our grpc services - scheduling periodic tasks (generally health checks) tied to the server lifecycle, and splitting services to different servers/ports. All changes are backwards compatible.