### PR TITLE
Support taking in a config object when constructing a PlatformService

### DIFF
--- a/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
+++ b/platform-service-framework/src/main/java/org/hypertrace/core/serviceframework/PlatformService.java
@@ -57,6 +57,11 @@ public abstract class PlatformService {
     this.serviceName = appConfig.getString(SERVICE_NAME_CONFIG);
   }
 
+  public PlatformService(Config appConfig){
+    this.appConfig = appConfig;
+    this.serviceName = appConfig.getString(SERVICE_NAME_CONFIG);
+  }
+
   // initialize the service. This method will always be called before start.
   protected abstract void doInit();
 


### PR DESCRIPTION
This enables scenarios where config is externally determined and passed directly instead of relying on the ConfigClient which always looks in specific directories. This is to enable passing config when running in consolidated mode