### PR TITLE
refactor: allow building service using definition

### DIFF
--- a/platform-grpc-service-framework/build.gradle.kts
+++ b/platform-grpc-service-framework/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   api(platform("io.grpc:grpc-bom:1.47.0"))
   api("io.grpc:grpc-api")
   api("io.grpc:grpc-services")
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.6")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.9.1")
   api("com.typesafe:config:1.4.2")
   api(project(":service-framework-spi"))
 
@@ -18,5 +18,5 @@ dependencies {
   compileOnly("org.projectlombok:lombok:1.18.24")
 
   implementation("org.slf4j:slf4j-api:1.7.36")
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.7.6")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.9.1")
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformService.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformService.java
@@ -1,9 +1,18 @@
 package org.hypertrace.core.serviceframework.grpc;
 
 import io.grpc.BindableService;
+import io.grpc.ServerServiceDefinition;
 import lombok.Value;
 
 @Value
 public class GrpcPlatformService {
-  BindableService grpcService;
+  ServerServiceDefinition grpcServiceDefinition;
+
+  public GrpcPlatformService(BindableService grpcService) {
+    this(grpcService.bindService());
+  }
+
+  public GrpcPlatformService(ServerServiceDefinition grpcService) {
+    this.grpcServiceDefinition = grpcService;
+  }
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -94,7 +94,7 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
     serverDefinition.getServiceFactories().stream()
         .map(factory -> factory.buildServices(containerEnvironment))
         .flatMap(Collection::stream)
-        .map(GrpcPlatformService::getGrpcService)
+        .map(GrpcPlatformService::getGrpcServiceDefinition)
         .map(InterceptorUtil::wrapInterceptors)
         .forEach(
             service -> {

--- a/platform-http-service-framework/build.gradle.kts
+++ b/platform-http-service-framework/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   api(project(":platform-service-framework"))
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.6")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.9.1")
   api("com.typesafe:config:1.4.2")
   api("javax.servlet:javax.servlet-api:4.0.1")
   api("com.google.inject:guice:5.1.0")


### PR DESCRIPTION
## Description
Allowing using a service definition in addition to a bindable service when declaring a service. This allows wrapping service-local interceptors (https://github.com/hypertrace/service-framework/pull/58 added support for server-wide interceptors).