### PR TITLE
fix: upgrade libs for fix vulnerabilities

### DIFF
--- a/platform-metrics/build.gradle.kts
+++ b/platform-metrics/build.gradle.kts
@@ -11,7 +11,7 @@ tasks.test {
 
 dependencies {
   api("com.typesafe:config:1.4.2")
-  api("io.dropwizard.metrics:metrics-core:4.2.13")
+  api("io.dropwizard.metrics:metrics-core:4.2.16")
   api("io.micrometer:micrometer-core:1.10.2")
   api("javax.servlet:javax.servlet-api:3.1.0")
 
@@ -20,7 +20,7 @@ dependencies {
   implementation("io.github.mweirauch:micrometer-jvm-extras:0.2.2")
   implementation("org.slf4j:slf4j-api:1.7.36")
   implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.19.0")
-  implementation("io.dropwizard.metrics:metrics-jvm:4.2.13")
+  implementation("io.dropwizard.metrics:metrics-jvm:4.2.16")
   implementation("io.prometheus:simpleclient_dropwizard:0.12.0")
   implementation("io.prometheus:simpleclient_servlet:0.12.0")
   implementation("io.prometheus:simpleclient_pushgateway:0.12.0")

--- a/platform-service-framework/build.gradle.kts
+++ b/platform-service-framework/build.gradle.kts
@@ -17,7 +17,12 @@ dependencies {
   api("com.typesafe:config:1.4.2")
 
   // Use for thread dump servlet
-  implementation("io.dropwizard.metrics:metrics-servlets:4.2.13")
+  implementation("io.dropwizard.metrics:metrics-servlets:4.2.16")
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2") {
+      because("version 2.12.7.1 has a vulnerability https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424")
+    }
+  }
   implementation("org.eclipse.jetty:jetty-servlet:9.4.50.v20221201")
 
   // Use for metrics servlet


### PR DESCRIPTION
- Upgrade libs to fix vulnerabilities
Existing synk repot:
```
Testing /Users/ronak/hypertrace/service-framework...

Tested 73 dependencies for known issues, found 1 issue, 2 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424] in com.fasterxml.jackson.core:jackson-databind@2.12.7.1
    introduced by io.dropwizard.metrics:metrics-servlets@4.2.13 > com.fasterxml.jackson.core:jackson-databind@2.12.7.1 and 1 other path(s)
  This issue was fixed in versions: 2.13.4

Organization:      kotharironak
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      service-framework/platform-service-framework
Open source:       no
Project path:      /Users/ronak/hypertrace/service-framework
Licenses:          enabled
```

Fixed the above issue.