### PR TITLE
chore: upgrade grpc due to vuln

### DIFF
--- a/platform-grpc-service-framework/build.gradle.kts
+++ b/platform-grpc-service-framework/build.gradle.kts
@@ -7,10 +7,10 @@ plugins {
 
 dependencies {
   api(project(":platform-service-framework"))
-  api(platform("io.grpc:grpc-bom:1.56.0"))
+  api(platform("io.grpc:grpc-bom:1.57.2"))
   api("io.grpc:grpc-api")
   api("io.grpc:grpc-services")
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.1")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.2")
   api("com.typesafe:config:1.4.2")
   api(project(":service-framework-spi"))
 
@@ -19,5 +19,5 @@ dependencies {
 
   implementation(project(":platform-metrics"))
   implementation("org.slf4j:slf4j-api:1.7.36")
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.12.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.12.2")
 }

--- a/platform-http-service-framework/build.gradle.kts
+++ b/platform-http-service-framework/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   api(project(":platform-service-framework"))
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.1")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.2")
   api("com.typesafe:config:1.4.2")
   api("javax.servlet:javax.servlet-api:4.0.1")
   api("com.google.inject:guice:5.1.0")


### PR DESCRIPTION
## Description
This PR updates grpc as there is a new vulnerability reported on the older version being used - `CVE-2023-33953`