### PR TITLE
refactor: update http framework to provide inprocess grpc reg

### DIFF
--- a/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/HttpContainerEnvironment.java
+++ b/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/HttpContainerEnvironment.java
@@ -1,11 +1,11 @@
 package org.hypertrace.core.serviceframework.http;
 
 import com.typesafe.config.Config;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.spi.PlatformServiceLifecycle;
 
 public interface HttpContainerEnvironment {
-  GrpcChannelRegistry getChannelRegistry();
+  InProcessGrpcChannelRegistry getChannelRegistry();
 
   Config getConfig(String serviceName);
 

--- a/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/StandAloneHttpContainerEnvironment.java
+++ b/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/StandAloneHttpContainerEnvironment.java
@@ -3,13 +3,13 @@ package org.hypertrace.core.serviceframework.http;
 import com.typesafe.config.Config;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
 import org.hypertrace.core.serviceframework.spi.PlatformServiceLifecycle;
 
 @AllArgsConstructor
 public class StandAloneHttpContainerEnvironment implements HttpContainerEnvironment {
-  @Getter private final GrpcChannelRegistry channelRegistry;
+  @Getter private final InProcessGrpcChannelRegistry channelRegistry;
   @Getter private final PlatformServiceLifecycle lifecycle;
   private final ConfigClient configClient;
 

--- a/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/StandAloneHttpPlatformServiceContainer.java
+++ b/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/StandAloneHttpPlatformServiceContainer.java
@@ -7,8 +7,8 @@ import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientIntercept
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.hypertrace.core.grpcutils.client.GrpcRegistryConfig;
+import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
 import org.hypertrace.core.serviceframework.PlatformService;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
 import org.hypertrace.core.serviceframework.http.jetty.JettyHttpServerBuilder;
@@ -17,12 +17,12 @@ import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 @Slf4j
 public abstract class StandAloneHttpPlatformServiceContainer extends PlatformService {
   private HttpContainer container;
-  private final GrpcChannelRegistry grpcChannelRegistry;
+  private final InProcessGrpcChannelRegistry grpcChannelRegistry;
 
   public StandAloneHttpPlatformServiceContainer(ConfigClient config) {
     super(config);
     grpcChannelRegistry =
-        new GrpcChannelRegistry(
+        new InProcessGrpcChannelRegistry(
             GrpcRegistryConfig.builder()
                 .defaultInterceptor(
                     new MetricCollectingClientInterceptor(


### PR DESCRIPTION
## Description

Subclass of grpc reg should be compatible with existing usages. This enables an http and grpc server to share the same container and take advantage of in process transport.