### PR TITLE
upgraded version for org.eclipse.jetty:jetty-servlet

### DIFF
--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -22,7 +22,7 @@
    Ref:
    https://github.com/eclipse/jetty.project/security/advisories/GHSA-3gh6-v5v9-6v9j
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-servlets@9.4.52\..*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-servlets@9.4.53\..*$</packageUrl>
     <vulnerabilityName>CVE-2023-36479</vulnerabilityName>
   </suppress>
 </suppressions> 

--- a/platform-http-service-framework/build.gradle.kts
+++ b/platform-http-service-framework/build.gradle.kts
@@ -15,9 +15,9 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.36")
   implementation("com.google.inject.extensions:guice-servlet:5.1.0")
   implementation("com.google.guava:guava:31.1-jre")
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.53")
-  implementation("org.eclipse.jetty:jetty-server:9.4.53")
-  implementation("org.eclipse.jetty:jetty-servlets:9.4.53")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.53.v20231009")
+  implementation("org.eclipse.jetty:jetty-server:9.4.53.v20231009")
+  implementation("org.eclipse.jetty:jetty-servlets:9.4.53.v20231009")
 
   annotationProcessor("org.projectlombok:lombok:1.18.24")
   compileOnly("org.projectlombok:lombok:1.18.24")

--- a/platform-http-service-framework/build.gradle.kts
+++ b/platform-http-service-framework/build.gradle.kts
@@ -15,9 +15,9 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.36")
   implementation("com.google.inject.extensions:guice-servlet:5.1.0")
   implementation("com.google.guava:guava:31.1-jre")
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.52.v20230823")
-  implementation("org.eclipse.jetty:jetty-server:9.4.52.v20230823")
-  implementation("org.eclipse.jetty:jetty-servlets:9.4.52.v20230823")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.53")
+  implementation("org.eclipse.jetty:jetty-server:9.4.53")
+  implementation("org.eclipse.jetty:jetty-servlets:9.4.53")
 
   annotationProcessor("org.projectlombok:lombok:1.18.24")
   compileOnly("org.projectlombok:lombok:1.18.24")

--- a/platform-metrics/build.gradle.kts
+++ b/platform-metrics/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   implementation("io.prometheus:simpleclient_dropwizard:0.12.0")
   implementation("io.prometheus:simpleclient_servlet:0.12.0")
   implementation("io.prometheus:simpleclient_pushgateway:0.12.0")
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.53")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.53.v20231009")
   implementation("com.google.guava:guava:32.0.1-jre")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")

--- a/platform-metrics/build.gradle.kts
+++ b/platform-metrics/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   implementation("io.prometheus:simpleclient_dropwizard:0.12.0")
   implementation("io.prometheus:simpleclient_servlet:0.12.0")
   implementation("io.prometheus:simpleclient_pushgateway:0.12.0")
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.52.v20230823")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.53")
   implementation("com.google.guava:guava:32.0.1-jre")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")

--- a/platform-service-framework/build.gradle.kts
+++ b/platform-service-framework/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   constraints {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
   }
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.52.v20230823")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.53")
 
   // Use for metrics servlet
   implementation("io.prometheus:simpleclient_servlet:0.12.0")
@@ -38,6 +38,6 @@ dependencies {
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.19.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
   testImplementation("org.mockito:mockito-core:4.8.0")
-  testImplementation("org.eclipse.jetty:jetty-servlet:9.4.52.v20230823:tests")
-  testImplementation("org.eclipse.jetty:jetty-http:9.4.52.v20230823:tests")
+  testImplementation("org.eclipse.jetty:jetty-servlet:9.4.53:tests")
+  testImplementation("org.eclipse.jetty:jetty-http:9.4.53:tests")
 }

--- a/platform-service-framework/build.gradle.kts
+++ b/platform-service-framework/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   constraints {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
   }
-  implementation("org.eclipse.jetty:jetty-servlet:9.4.53")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.53.v20231009")
 
   // Use for metrics servlet
   implementation("io.prometheus:simpleclient_servlet:0.12.0")
@@ -38,6 +38,6 @@ dependencies {
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.19.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
   testImplementation("org.mockito:mockito-core:4.8.0")
-  testImplementation("org.eclipse.jetty:jetty-servlet:9.4.53:tests")
-  testImplementation("org.eclipse.jetty:jetty-http:9.4.53:tests")
+  testImplementation("org.eclipse.jetty:jetty-servlet:9.4.53.v20231009:tests")
+  testImplementation("org.eclipse.jetty:jetty-http:9.4.53.v20231009:tests")
 }


### PR DESCRIPTION
## Description
Upgraded version for org.eclipse.jetty:jetty-servlet from 9.4.52.v20230823 to 9.4.53.v20231009 to resolve vulnerability CVE-2023-36478

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
