### PR TITLE
Expose grpc latency histogram metrics

### DIFF
--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -18,6 +18,7 @@ import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientIntercept
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingServerInterceptor;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -217,8 +218,8 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
             : DEFAULT_MAX_LATENCY_HISTOGRAM_BUCKET_DURATION;
     while (currDuration.compareTo(DEFAULT_MIN_LATENCY_HISTOGRAM_BUCKET_DURATION) > 0) {
       histogramBuckets.add(currDuration);
-      currDuration = currDuration.dividedBy(LATENCY_HISTOGRAM_BUCKET_FACTOR);
-      currDuration = Duration.ofMillis(currDuration.toMillis()); // Round off to milliseconds
+      currDuration =
+          currDuration.dividedBy(LATENCY_HISTOGRAM_BUCKET_FACTOR).truncatedTo(ChronoUnit.MILLIS);
     }
     return histogramBuckets.toArray(new Duration[histogramBuckets.size()]);
   }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -210,17 +210,17 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
   }
 
   private Duration[] generateLatencyHistogramBuckets() {
-    ArrayList<Duration> histogram_buckets = new ArrayList<>();
-    Duration curr_duration =
+    ArrayList<Duration> histogramBuckets = new ArrayList<>();
+    Duration currDuration =
         getAppConfig().hasPath(MAX_LATENCY_HISTOGRAM_BUCKET_DURATION)
             ? getAppConfig().getDuration(MAX_LATENCY_HISTOGRAM_BUCKET_DURATION)
             : DEFAULT_MAX_LATENCY_HISTOGRAM_BUCKET_DURATION;
-    while (curr_duration.compareTo(DEFAULT_MIN_LATENCY_HISTOGRAM_BUCKET_DURATION) > 0) {
-      histogram_buckets.add(curr_duration);
-      curr_duration = curr_duration.dividedBy(LATENCY_HISTOGRAM_BUCKET_FACTOR);
-      curr_duration = Duration.ofMillis(curr_duration.toMillis()); // Round off to milliseconds
+    while (currDuration.compareTo(DEFAULT_MIN_LATENCY_HISTOGRAM_BUCKET_DURATION) > 0) {
+      histogramBuckets.add(currDuration);
+      currDuration = currDuration.dividedBy(LATENCY_HISTOGRAM_BUCKET_FACTOR);
+      currDuration = Duration.ofMillis(currDuration.toMillis()); // Round off to milliseconds
     }
-    return histogram_buckets.toArray(new Duration[histogram_buckets.size()]);
+    return histogramBuckets.toArray(new Duration[histogramBuckets.size()]);
   }
 
   protected InProcessGrpcChannelRegistry buildChannelRegistry() {


### PR DESCRIPTION
Exposing histogram bucket metrics for grpc latencies instead of percentile metrics to use in SLI dashboards

The buckets are generated based on a set max value (read from application.conf). The default max is set to 10000ms which generates 8 default buckets: [+Inf, 10000, 3330, 1110, 370, 120, 40, 10] (in ms) 