### PR TITLE
fix: make shutdown more graceful

### DIFF
--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -188,8 +188,8 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
 
   @Override
   protected void doStop() {
-    this.scheduledFutures.forEach(future -> future.cancel(true));
     healthStatusManager.enterTerminalState();
+    this.scheduledFutures.forEach(future -> future.cancel(true));
     this.servers.forEach(
         constructedServer ->
             ServerManagementUtil.shutdownServer(

--- a/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/StandAloneHttpPlatformServiceContainer.java
+++ b/platform-http-service-framework/src/main/java/org/hypertrace/core/serviceframework/http/StandAloneHttpPlatformServiceContainer.java
@@ -48,8 +48,8 @@ public abstract class StandAloneHttpPlatformServiceContainer extends PlatformSer
   @Override
   protected void doStop() {
     log.info("Stopping service {}", this.getServiceName());
-    grpcChannelRegistry.shutdown(after(10, SECONDS));
     this.container.stop();
+    grpcChannelRegistry.shutdown(after(10, SECONDS));
   }
 
   @Override


### PR DESCRIPTION
## Description
Couple existing issues here:
- clients were being shutdown before the server, meaning we were unable to drain pending requests at the moment of shutdown
- if the service fails to start, the shutdown hook was throwing a NPE because not all variables had values yet. No functional impact here, but commonly caused log confusion.
