### PR TITLE
refactor: add interceptor to verify clients are setting timeouts

### DIFF
--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -8,7 +8,7 @@
     <cpe>cpe:/a:grpc:grpc</cpe>
     <cpe>cpe:/a:utils_project:utils</cpe>
   </suppress>
-  <suppress until="2024-05-31Z">
+  <suppress until="2024-07-31Z">
     <notes><![CDATA[
    This CVE is declared fixed from 9.4.52, but the vuln db is not reflecting that. Suppress that specific version until
    db is updated.

--- a/platform-grpc-service-framework/build.gradle.kts
+++ b/platform-grpc-service-framework/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   api(platform("io.grpc:grpc-bom:1.60.0"))
   api("io.grpc:grpc-api")
   api("io.grpc:grpc-services")
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.2")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.4")
   api("com.typesafe:config:1.4.2")
   api(project(":service-framework-spi"))
 
@@ -21,5 +21,5 @@ dependencies {
   implementation("io.grpc:grpc-inprocess")
   implementation("io.grpc:grpc-netty")
   implementation("org.slf4j:slf4j-api:1.7.36")
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.13.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.13.4")
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -37,6 +37,7 @@ import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.hypertrace.core.grpcutils.client.GrpcRegistryConfig;
 import org.hypertrace.core.grpcutils.client.InProcessGrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.client.TimeoutVerifyingClientInterceptor;
 import org.hypertrace.core.grpcutils.server.InterceptorUtil;
 import org.hypertrace.core.grpcutils.server.ServerManagementUtil;
 import org.hypertrace.core.serviceframework.PlatformService;
@@ -238,6 +239,7 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
                     timerBuilder ->
                         timerBuilder.serviceLevelObjectives(generateLatencyHistogramBuckets()),
                     Status.Code.OK))
+            .defaultInterceptor(new TimeoutVerifyingClientInterceptor())
             .build());
   }
 

--- a/platform-http-service-framework/build.gradle.kts
+++ b/platform-http-service-framework/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   api(project(":platform-service-framework"))
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.2")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.4")
   api("com.typesafe:config:1.4.2")
   api("javax.servlet:javax.servlet-api:4.0.1")
   api("com.google.inject:guice:5.1.0")


### PR DESCRIPTION
## Description
This new interceptor verifies that clients are adding timeouts. It is lenient and logs a warning but does not block a request if missing a timeout.