### PR TITLE
 Add optional maxConnectionAge and maxConnectionAgeGrace support to G…

### DIFF
--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServerDefinition.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServerDefinition.java
@@ -17,6 +17,8 @@ public class GrpcPlatformServerDefinition {
   int port;
   int maxInboundMessageSize;
   @Builder.Default int maxRstPerMinute = 500;
+  @Builder.Default long maxConnectionAgeInSeconds = 0;
+  @Builder.Default long maxConnectionAgeGraceInSeconds = 0;
   @Singular Collection<GrpcPlatformServiceFactory> serviceFactories;
   @Singular List<ServerInterceptor> serverInterceptors;
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServerDefinition.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServerDefinition.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.serviceframework.grpc;
 
 import io.grpc.ServerInterceptor;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import lombok.AccessLevel;
@@ -17,8 +18,8 @@ public class GrpcPlatformServerDefinition {
   int port;
   int maxInboundMessageSize;
   @Builder.Default int maxRstPerMinute = 500;
-  @Builder.Default long maxConnectionAgeInSeconds = 0;
-  @Builder.Default long maxConnectionAgeGraceInSeconds = 0;
+  @Builder.Default Duration maxConnectionAge = Duration.ZERO;
+  @Builder.Default Duration maxConnectionAgeGrace = Duration.ZERO;
   @Singular Collection<GrpcPlatformServiceFactory> serviceFactories;
   @Singular List<ServerInterceptor> serverInterceptors;
 }

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -286,6 +286,12 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
     if (serverDefinition.getMaxRstPerMinute() > 0) {
       builder.maxRstFramesPerWindow(serverDefinition.getMaxRstPerMinute(), 60);
     }
+    if (serverDefinition.getMaxConnectionAgeInSeconds() > 0) {
+      builder.maxConnectionAge(serverDefinition.getMaxConnectionAgeInSeconds(), SECONDS);
+    }
+    if (serverDefinition.getMaxConnectionAgeGraceInSeconds() > 0) {
+      builder.maxConnectionAgeGrace(serverDefinition.getMaxConnectionAgeGraceInSeconds(), SECONDS);
+    }
     // add micrometer-grpc interceptor to collect server metrics.
     builder.intercept(
         new MetricCollectingServerInterceptor(

--- a/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
+++ b/platform-grpc-service-framework/src/main/java/org/hypertrace/core/serviceframework/grpc/GrpcPlatformServiceContainer.java
@@ -286,11 +286,12 @@ abstract class GrpcPlatformServiceContainer extends PlatformService {
     if (serverDefinition.getMaxRstPerMinute() > 0) {
       builder.maxRstFramesPerWindow(serverDefinition.getMaxRstPerMinute(), 60);
     }
-    if (serverDefinition.getMaxConnectionAgeInSeconds() > 0) {
-      builder.maxConnectionAge(serverDefinition.getMaxConnectionAgeInSeconds(), SECONDS);
+    if (!serverDefinition.getMaxConnectionAge().isZero()) {
+      builder.maxConnectionAge(serverDefinition.getMaxConnectionAge().toMillis(), MILLISECONDS);
     }
-    if (serverDefinition.getMaxConnectionAgeGraceInSeconds() > 0) {
-      builder.maxConnectionAgeGrace(serverDefinition.getMaxConnectionAgeGraceInSeconds(), SECONDS);
+    if (!serverDefinition.getMaxConnectionAgeGrace().isZero()) {
+      builder.maxConnectionAgeGrace(
+          serverDefinition.getMaxConnectionAgeGrace().toMillis(), MILLISECONDS);
     }
     // add micrometer-grpc interceptor to collect server metrics.
     builder.intercept(


### PR DESCRIPTION
### Description
Adds support for configuring maxConnectionAge and maxConnectionAgeGrace on the gRPC Netty server via GrpcPlatformServerDefinition.

### Problem
Currently, gRPC connections to services built on this framework are long-lived with no upper bound on connection lifetime. 
Once a persistent HTTP/2 connection is created at the time of DNS resolution, it sticks to the resolved pods and there is no rotation.

### Solution
Two new optional fields on GrpcPlatformServerDefinition:         

**maxConnectionAgeInSeconds** : Maximum time a connection may exist before the server sends a GOAWAY.
**maxConnectionAgeGraceInSeconds**:  Grace period after GOAWAY for in-flight RPCs to complete before the connection is forcibly closed.

These are wired into NettyServerBuilder.maxConnectionAge() and NettyServerBuilder.maxConnectionAgeGrace() in GrpcPlatformServiceContainer.initializeBuilder()

 ### Changes                                                                                                                                                                                                                                                
 GrpcPlatformServerDefinition.java — Added maxConnectionAgeInSeconds and maxConnectionAgeGraceInSeconds fields with @Builder.Default of 0.                                                          
 GrpcPlatformServiceContainer.java — Apply the new fields on the NettyServerBuilder in initializeBuilder() when values are > 0.

  ### Backward compatibility                                                                                                                                                                               
  Fully backward compatible. Both fields default to 0, which preserves the existing behavior (no connection age limit). No changes required in existing consumers.                   
  
                    
 ### Testing                                                                                                                                                                                              
  - Verified the module compiles cleanly                                                                                                     
  - Full build passes
  - No existing unit tests in this module to regress                                                                                                                                                